### PR TITLE
Send QUIT before kill, because after kill we may not be able to send msgs

### DIFF
--- a/irctest/cases.py
+++ b/irctest/cases.py
@@ -44,8 +44,8 @@ class BaseClientTestCase(_IrcTestCase):
         self.controller = self.controllerClass()
         self._setUpServer()
     def tearDown(self):
-        self.controller.kill()
         self.conn.sendall(b'QUIT :end of test.')
+        self.controller.kill()
         self.conn_file.close()
         self.conn.close()
         self.server.close()


### PR DESCRIPTION
This fixes a small issue with my controller.

`controller.kill()` may make the remote process kill the network connection, which ends up in this sort of an error:
```
======================================================================
ERROR: testPlainLarge (test_sasl.CapTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dan/code/irc/irctest/irctest/cases.py", line 48, in tearDown
    self.conn.sendall(b'QUIT :end of test.')
ConnectionResetError: [Errno 104] Connection reset by peer
```

Putting the `QUIT` message before the `kill` message fixes this though.