### PR TITLE
Support skipping unsupported SASL mechanisms

### DIFF
--- a/irctest/client_tests/test_sasl.py
+++ b/irctest/client_tests/test_sasl.py
@@ -17,8 +17,6 @@ IRX9cyi2wdYg9mUUYyh9GKdBCYHGUJAiCA==
 
 class SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper):
     def checkMechanismSupport(self, mechanism):
-        if not hasattr(self.controller, 'supported_sasl_mechanisms'):
-            return
         if mechanism in self.controller.supported_sasl_mechanisms:
             return
         self.skipTest('SASL Mechanism not supported: {}'.format(mechanism))
@@ -30,6 +28,7 @@ class SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper):
                 password='sesame',
                 )
         m = self.negotiateCapabilities(['sasl'], auth=auth)
+        self.checkMechanismSupport('PLAIN')
         self.assertEqual(m, Message([], None, 'AUTHENTICATE', ['PLAIN']))
         self.sendLine('AUTHENTICATE +')
         m = self.getMessage()
@@ -47,6 +46,7 @@ class SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper):
                 password='sesame',
                 )
         m = self.negotiateCapabilities(['sasl=EXTERNAL'], auth=auth)
+        self.checkMechanismSupport('PLAIN')
         self.assertEqual(self.acked_capabilities, {'sasl'})
         if m == Message([], None, 'CAP', ['END']):
             # IRCv3.2-style
@@ -66,6 +66,7 @@ class SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper):
         authstring = base64.b64encode(b'\x00'.join(
             [b'foo', b'foo', b'bar'*200])).decode()
         m = self.negotiateCapabilities(['sasl'], auth=auth)
+        self.checkMechanismSupport('PLAIN')
         self.assertEqual(m, Message([], None, 'AUTHENTICATE', ['PLAIN']))
         self.sendLine('AUTHENTICATE +')
         m = self.getMessage()
@@ -92,6 +93,7 @@ class SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper):
         authstring = base64.b64encode(b'\x00'.join(
             [b'foo', b'foo', b'quux'*148])).decode()
         m = self.negotiateCapabilities(['sasl'], auth=auth)
+        self.checkMechanismSupport('PLAIN')
         self.assertEqual(m, Message([], None, 'AUTHENTICATE', ['PLAIN']))
         self.sendLine('AUTHENTICATE +')
         m = self.getMessage()
@@ -144,5 +146,6 @@ class Irc302SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper
                 password='sesame',
                 )
         m = self.negotiateCapabilities(['sasl=EXTERNAL'], auth=auth)
+        self.checkMechanismSupport('PLAIN')
         self.assertEqual(self.acked_capabilities, {'sasl'})
         self.assertEqual(m, Message([], None, 'CAP', ['END']))

--- a/irctest/client_tests/test_sasl.py
+++ b/irctest/client_tests/test_sasl.py
@@ -15,12 +15,14 @@ IRX9cyi2wdYg9mUUYyh9GKdBCYHGUJAiCA==
 -----END EC PRIVATE KEY-----
 """
 
-class SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper):
+class SaslMechanismCheck:
     def checkMechanismSupport(self, mechanism):
         if mechanism in self.controller.supported_sasl_mechanisms:
             return
         self.skipTest('SASL Mechanism not supported: {}'.format(mechanism))
 
+class SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper,
+                   SaslMechanismCheck):
     def testPlain(self):
         auth = authentication.Authentication(
                 mechanisms=[authentication.Mechanisms.plain],
@@ -138,7 +140,8 @@ class SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper):
         m = self.negotiateCapabilities(['sasl'], False)
         self.assertEqual(m, Message([], None, 'CAP', ['END']))
 
-class Irc302SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper):
+class Irc302SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper,
+                         SaslMechanismCheck):
     def testPlainNotAvailable(self):
         auth = authentication.Authentication(
                 mechanisms=[authentication.Mechanisms.plain],

--- a/irctest/client_tests/test_sasl.py
+++ b/irctest/client_tests/test_sasl.py
@@ -16,6 +16,13 @@ IRX9cyi2wdYg9mUUYyh9GKdBCYHGUJAiCA==
 """
 
 class SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper):
+    def checkMechanismSupport(self, mechanism):
+        if not hasattr(self.controller, 'supported_sasl_mechanisms'):
+            return
+        if mechanism in self.controller.supported_sasl_mechanisms:
+            return
+        self.skipTest('SASL Mechanism not supported: {}'.format(mechanism))
+
     def testPlain(self):
         auth = authentication.Authentication(
                 mechanisms=[authentication.Mechanisms.plain],
@@ -108,6 +115,7 @@ class SaslTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper):
                 ecdsa_key=ECDSA_KEY,
                 )
         m = self.negotiateCapabilities(['sasl'], auth=auth)
+        self.checkMechanismSupport('ECDSA-NIST256P-CHALLENGE')
         self.assertEqual(m, Message([], None, 'AUTHENTICATE', ['ECDSA-NIST256P-CHALLENGE']))
         self.sendLine('AUTHENTICATE +')
         m = self.getMessage()

--- a/irctest/controllers/limnoria.py
+++ b/irctest/controllers/limnoria.py
@@ -23,6 +23,8 @@ class LimnoriaController(BaseClientController, DirectoryBasedController):
             pass
         with self.open_file('conf/users.conf'):
             pass
+        self.supported_sasl_mechanisms = [
+            'PLAIN', 'ECDSA-NIST256P-CHALLENGE', 'EXTERNAL']
 
     def run(self, hostname, port, auth):
         # Runs a client with the config given as arguments

--- a/irctest/controllers/sopel.py
+++ b/irctest/controllers/sopel.py
@@ -22,6 +22,7 @@ class SopelController(BaseClientController):
         super().__init__()
         self.filename = next(tempfile._get_candidate_names()) + '.cfg'
         self.proc = None
+        self.supported_sasl_mechanisms = ['PLAIN']
     def kill(self):
         if self.proc:
             self.proc.kill()


### PR DESCRIPTION
Fixes #2, allows controllers to skip tests for unsupported SASL mechanisms.

Used by adding a line like this to the controller's `__init__()`:
```
self.supported_sasl_mechanisms = ['PLAIN']
```

Haven't looked into the table stuff yet since I'm not as familiar with unit testing, this just does the test skipping.