### PR TITLE
Add --server-start-delay for delay seconds, and cleanup mammon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# mammon
+.mammon.data.json

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,3 @@ docs/_build/
 
 # PyBuilder
 target/
-
-# mammon
-.mammon.data.json

--- a/irctest/__main__.py
+++ b/irctest/__main__.py
@@ -19,6 +19,7 @@ def main(args):
         module = 'irctest.client_tests'
     elif issubclass(controller_class, BaseServerController):
         module = 'irctest.server_tests'
+        _IrcTestCase.server_start_delay = args.server_start_delay
     else:
         print(r'{}.Controller should be a subclass of '
                 r'irctest.basecontroller.Base{{Client,Server}}Controller'
@@ -36,6 +37,9 @@ parser.add_argument('module', type=str,
         help='The module used to run the tested program.')
 parser.add_argument('--show-io', action='store_true',
         help='Show input/outputs with the tested program.')
+parser.add_argument('--server-start-delay', type=float, default=None,
+        help='Number of seconds to wait before querying a server.')
+
 
 args = parser.parse_args()
 main(args)

--- a/irctest/cases.py
+++ b/irctest/cases.py
@@ -155,7 +155,10 @@ class BaseServerTestCase(_IrcTestCase):
     def setUp(self):
         super().setUp()
         self.find_hostname_and_port()
-        self.controller.run(self.hostname, self.port)
+        kwargs = {}
+        if self.server_start_delay is not None:
+            kwargs['start_wait'] = self.server_start_delay
+        self.controller.run(self.hostname, self.port, **kwargs)
         self.clients = {}
     def tearDown(self):
         self.controller.kill()

--- a/irctest/controllers/inspircd.py
+++ b/irctest/controllers/inspircd.py
@@ -22,7 +22,7 @@ class InspircdController(BaseServerController, DirectoryBasedController):
         with self.open_file('server.conf'):
             pass
 
-    def run(self, hostname, port):
+    def run(self, hostname, port, start_wait=0.1):
         assert self.proc is None
         self.create_config()
         with self.open_file('server.conf') as fd:
@@ -32,7 +32,7 @@ class InspircdController(BaseServerController, DirectoryBasedController):
                 ))
         self.proc = subprocess.Popen(['inspircd', '--nofork', '--config',
             os.path.join(self.directory, 'server.conf')])
-        time.sleep(0.1) # FIXME: do better than this to wait for InspIRCd to start
+        time.sleep(start_wait) # FIXME: do better than this to wait for InspIRCd to start
 
 def get_irctest_controller_class():
     return InspircdController

--- a/irctest/controllers/mammon.py
+++ b/irctest/controllers/mammon.py
@@ -1,10 +1,7 @@
 import os
 import time
-import shutil
-import tempfile
 import subprocess
 
-from irctest import authentication
 from irctest.basecontrollers import BaseServerController, DirectoryBasedController
 
 TEMPLATE_CONFIG = """
@@ -54,7 +51,7 @@ server:
   recvq_len: 20
 """
 
-class InspircdController(BaseServerController, DirectoryBasedController):
+class MammonController(BaseServerController, DirectoryBasedController):
     def create_config(self):
         super().create_config()
         with self.open_file('server.conf'):
@@ -64,7 +61,7 @@ class InspircdController(BaseServerController, DirectoryBasedController):
         # Mammon does not seem to handle SIGTERM very well
         self.proc.kill()
 
-    def run(self, hostname, port):
+    def run(self, hostname, port, start_wait=0.5):
         assert self.proc is None
         self.create_config()
         with self.open_file('server.yml') as fd:
@@ -73,11 +70,9 @@ class InspircdController(BaseServerController, DirectoryBasedController):
                 hostname=hostname,
                 port=port,
                 ))
-        self.proc = subprocess.Popen(['python3', '-m', 'mammon', '--nofork', #'--debug',
+        self.proc = subprocess.Popen(['mammond', '--nofork', #'--debug',
             '--config', os.path.join(self.directory, 'server.yml')])
-        time.sleep(0.5) # FIXME: do better than this to wait for Mammon to start
+        time.sleep(start_wait) # FIXME: do better than this to wait for Mammon to start
 
 def get_irctest_controller_class():
-    return InspircdController
-
-
+    return MammonController


### PR DESCRIPTION
This adds a `--server-start-delay` argument to pass how many seconds to wait before querying a server, and cleans up the `mammon` controller a bit (also making it use the calling syntax from https://github.com/mammon-ircd/mammon/pull/56 ).

I can split these into two separate commits / PRs if desired.

**edit:** I should say, I need to have a different start delay because on this junky little laptop, mammon takes longer than 0.5 seconds to start, which results in a bunch of test failures.

Optimally, a second part to solving this start delay problem would be to make it specifically check to see if it can't connect the client, wait another `start_delay` seconds and then try to connect the client again (looping until it manages to connect).