### PR TITLE
Automatically wait for server to start when connecting

### DIFF
--- a/irctest/__main__.py
+++ b/irctest/__main__.py
@@ -20,7 +20,6 @@ def main(args):
         import irctest.client_tests as module
     elif issubclass(controller_class, BaseServerController):
         import irctest.server_tests as module
-        _IrcTestCase.server_start_delay = args.server_start_delay
     else:
         print(r'{}.Controller should be a subclass of '
                 r'irctest.basecontroller.Base{{Client,Server}}Controller'
@@ -41,8 +40,6 @@ parser.add_argument('module', type=str,
         help='The module used to run the tested program.')
 parser.add_argument('--show-io', action='store_true',
         help='Show input/outputs with the tested program.')
-parser.add_argument('--server-start-delay', type=float, default=None,
-        help='Number of seconds to wait before querying a server.')
 
 
 args = parser.parse_args()

--- a/irctest/basecontrollers.py
+++ b/irctest/basecontrollers.py
@@ -2,7 +2,9 @@ import os
 import shutil
 import socket
 import tempfile
+import time
 import subprocess
+import psutil
 
 from .optional_extensions import NotImplementedByController
 
@@ -47,4 +49,11 @@ class BaseServerController(_BaseController):
         raise NotImplementedError()
     def registerUser(self, case, username):
         raise NotImplementedByController('registration')
+    def wait_for_port(self, proc, port):
+        port_open = False
+        while not port_open:
+            time.sleep(0.1)
+            for conn in psutil.Process(proc.pid).connections():
+                if conn.laddr[1] == port:
+                    port_open = True
 

--- a/irctest/cases.py
+++ b/irctest/cases.py
@@ -159,10 +159,7 @@ class BaseServerTestCase(_IrcTestCase):
     def setUp(self):
         super().setUp()
         self.find_hostname_and_port()
-        kwargs = {}
-        if self.server_start_delay is not None:
-            kwargs['start_wait'] = self.server_start_delay
-        self.controller.run(self.hostname, self.port, **kwargs)
+        self.controller.run(self.hostname, self.port)
         self.clients = {}
     def tearDown(self):
         self.controller.kill()

--- a/irctest/controllers/inspircd.py
+++ b/irctest/controllers/inspircd.py
@@ -22,7 +22,7 @@ class InspircdController(BaseServerController, DirectoryBasedController):
         with self.open_file('server.conf'):
             pass
 
-    def run(self, hostname, port, start_wait=0.1):
+    def run(self, hostname, port):
         assert self.proc is None
         self.create_config()
         with self.open_file('server.conf') as fd:
@@ -32,7 +32,7 @@ class InspircdController(BaseServerController, DirectoryBasedController):
                 ))
         self.proc = subprocess.Popen(['inspircd', '--nofork', '--config',
             os.path.join(self.directory, 'server.conf')])
-        time.sleep(start_wait) # FIXME: do better than this to wait for InspIRCd to start
+        self.wait_for_port(self.proc, port)
 
 def get_irctest_controller_class():
     return InspircdController

--- a/irctest/controllers/mammon.py
+++ b/irctest/controllers/mammon.py
@@ -64,7 +64,7 @@ class MammonController(BaseServerController, DirectoryBasedController):
         # Mammon does not seem to handle SIGTERM very well
         self.proc.kill()
 
-    def run(self, hostname, port, start_wait=0.5):
+    def run(self, hostname, port):
         assert self.proc is None
         self.create_config()
         with self.open_file('server.yml') as fd:
@@ -75,7 +75,7 @@ class MammonController(BaseServerController, DirectoryBasedController):
                 ))
         self.proc = subprocess.Popen(['mammond', '--nofork', #'--debug',
             '--config', os.path.join(self.directory, 'server.yml')])
-        time.sleep(start_wait) # FIXME: do better than this to wait for Mammon to start
+        self.wait_for_port(self.proc, port)
 
     def registerUser(self, case, username):
         # XXX: Move this somewhere else when

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 limnoria>2012.08.04 # Needs MultipleReplacer, from 1a64f105
+psutil>3.1.0 # Fixes #640


### PR DESCRIPTION
This makes it so if we can't connect to a server, it waits half a second then tries again, looping until we connect. This doesn't have a maximum wait time, it just keeps going until either it connects or irctest is killed.

Maybe something like this (doing it automatically) could be used to replace the explicit server start wait time setting? Or would it be useful to have both?