### PR TITLE
Don't pass a 'config' argument to the controller, only Oragono had it.

### DIFF
--- a/irctest/basecontrollers.py
+++ b/irctest/basecontrollers.py
@@ -13,13 +13,14 @@ class _BaseController:
     A software controller is an object that handles configuring and running
     a process (eg. a server or a client), as well as sending it instructions
     that are not part of the IRC specification."""
-    pass
+    def __init__(self, test_config):
+        self.test_config = test_config
 
 class DirectoryBasedController(_BaseController):
     """Helper for controllers whose software configuration is based on an
     arbitrary directory."""
-    def __init__(self):
-        super().__init__()
+    def __init__(self, test_config):
+        super().__init__(test_config)
         self.directory = None
         self.proc = None
 

--- a/irctest/cases.py
+++ b/irctest/cases.py
@@ -18,6 +18,14 @@ class _IrcTestCase(unittest.TestCase):
     """Base class for test cases."""
     controllerClass = None # Will be set by __main__.py
 
+    @staticmethod
+    def config():
+        """Some configuration to pass to the controllers.
+        For example, Oragono only enables its MySQL support if
+        config()["chathistory"]=True.
+        """
+        return {}
+
     def description(self):
         method_doc = self._testMethodDoc
         if not method_doc:
@@ -29,7 +37,7 @@ class _IrcTestCase(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.controller = self.controllerClass()
+        self.controller = self.controllerClass(self.config())
         self.inbuffer = []
         if self.show_io:
             print('---- new test ----')
@@ -235,15 +243,12 @@ class BaseServerTestCase(_IrcTestCase):
     invalid_metadata_keys = frozenset()
     def setUp(self):
         super().setUp()
-        config = None
-        if hasattr(self, 'customizedConfig'):
-            config = self.customizedConfig()
         self.server_support = {}
         self.find_hostname_and_port()
         self.controller.run(self.hostname, self.port, password=self.password,
                 valid_metadata_keys=self.valid_metadata_keys,
                 invalid_metadata_keys=self.invalid_metadata_keys,
-                ssl=self.ssl, config=config)
+                ssl=self.ssl)
         self.clients = {}
     def tearDown(self):
         self.controller.kill()

--- a/irctest/controllers/oragono.py
+++ b/irctest/controllers/oragono.py
@@ -168,6 +168,16 @@ class OragonoController(BaseServerController, DirectoryBasedController):
         if config is None:
             config = copy.deepcopy(BASE_CONFIG)
 
+        enable_chathistory = self.test_config.get("chathistory")
+        enable_roleplay = self.test_config.get("oragono_roleplay")
+        if enable_chathistory or enable_roleplay:
+            config = self.addMysqlToConfig(config)
+
+        if enable_roleplay:
+            config['roleplay'] = {
+                'enabled': True,
+            }
+
         self.port = port
         bind_address = "127.0.0.1:%s" % (port,)
         listener_conf = None # plaintext

--- a/irctest/server_tests/test_chathistory.py
+++ b/irctest/server_tests/test_chathistory.py
@@ -27,6 +27,11 @@ def validate_chathistory_batch(msgs):
     return result
 
 class ChathistoryTestCase(cases.BaseServerTestCase):
+    @staticmethod
+    def config():
+        return {
+        "chathistory": True,
+    }
 
     @cases.SpecificationSelector.requiredBySpecification('Oragono')
     def testInvalidTargets(self):
@@ -122,9 +127,6 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
 
         self.validate_echo_messages(NUM_MESSAGES, echo_messages)
         self.validate_chathistory(echo_messages, 1, chname)
-
-    def customizedConfig(self):
-        return self.controller.addMysqlToConfig()
 
     @cases.SpecificationSelector.requiredBySpecification('Oragono')
     def testChathistoryDMs(self):

--- a/irctest/server_tests/test_relaymsg.py
+++ b/irctest/server_tests/test_relaymsg.py
@@ -7,9 +7,11 @@ RELAYMSG_CAP = 'draft/relaymsg'
 RELAYMSG_TAG_NAME = 'draft/relaymsg'
 
 class RelaymsgTestCase(cases.BaseServerTestCase):
-
-    def customizedConfig(self):
-        return self.controller.addMysqlToConfig()
+    @staticmethod
+    def config():
+        return {
+            "chathistory": True,
+        }
 
     @cases.SpecificationSelector.requiredBySpecification('Oragono')
     def testRelaymsg(self):

--- a/irctest/server_tests/test_roleplay.py
+++ b/irctest/server_tests/test_roleplay.py
@@ -3,13 +3,11 @@ from irctest.numerics import ERR_CANNOTSENDRP
 from irctest.irc_utils.junkdrawer import random_name
 
 class RoleplayTestCase(cases.BaseServerTestCase):
-
-    def customizedConfig(self):
-        config = self.controller.baseConfig()
-        config['roleplay'] = {
-            'enabled': True,
+    @staticmethod
+    def config():
+        return {
+            "oragono_roleplay": True,
         }
-        return self.controller.addMysqlToConfig(config)
 
     @cases.SpecificationSelector.requiredBySpecification('Oragono')
     def testRoleplay(self):

--- a/irctest/server_tests/test_znc_playback.py
+++ b/irctest/server_tests/test_znc_playback.py
@@ -16,9 +16,11 @@ def extract_playback_privmsgs(messages):
 
 
 class ZncPlaybackTestCase(cases.BaseServerTestCase):
-
-    def customizedConfig(self):
-        return self.controller.addMysqlToConfig()
+    @staticmethod
+    def config():
+        return {
+            "chathistory": True,
+        }
 
     @cases.SpecificationSelector.requiredBySpecification('Oragono')
     def testZncPlayback(self):


### PR DESCRIPTION
Instead, annotate tests with the optional features they may need from the IRCd.