### PR TITLE
remove sleep from read loops

### DIFF
--- a/irctest/client_mock.py
+++ b/irctest/client_mock.py
@@ -49,6 +49,8 @@ class ClientMock:
                     if not assert_get_one and not synchronize and data == b"":
                         # Received nothing
                         return []
+                    if self.show_io:
+                        print("{:.3f} {}: waiting…".format(time.time(), self.name))
                     continue
                 except ConnectionResetError:
                     raise ConnectionClosed()

--- a/irctest/client_mock.py
+++ b/irctest/client_mock.py
@@ -49,9 +49,6 @@ class ClientMock:
                     if not assert_get_one and not synchronize and data == b"":
                         # Received nothing
                         return []
-                    if self.show_io:
-                        print("{:.3f} {}: waiting…".format(time.time(), self.name))
-                    time.sleep(0.1)
                     continue
                 except ConnectionResetError:
                     raise ConnectionClosed()
@@ -61,7 +58,6 @@ class ClientMock:
                         raise ConnectionClosed()
                 data += new_data
                 if not new_data.endswith(b"\r\n"):
-                    time.sleep(0.1)
                     continue
                 if not synchronize:
                     got_pong = True

--- a/irctest/server_tests/test_lusers.py
+++ b/irctest/server_tests/test_lusers.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 import re
-import time
 
 from irctest import cases
 from irctest.numerics import (
@@ -137,7 +136,6 @@ class LusersUnregisteredTestCase(LusersTestCase):
             msg = self.getRegistrationMessage(client_name)
             if msg.command in (ERR_NOTREGISTERED, "PONG"):
                 break
-            time.sleep(0.01)
         else:
             assert False, (
                 "Sent a PING before registration, "


### PR DESCRIPTION
recv() should block as necessary up to the 1-second timeout;
connection failures will break out of the loop with an exception.
There shouldn't be a case where we incur a busy wait.