### PR TITLE
Use a dedicated 'deprecated' mark instead of add '-deprecated' for each spec

### DIFF
--- a/irctest/cases.py
+++ b/irctest/cases.py
@@ -542,20 +542,20 @@ class OptionalityHelper:
         return decorator
 
 
-class SpecificationSelector:
-    def requiredBySpecification(*specifications, strict=False):
-        specifications = frozenset(
-            Specifications.of_name(s) if isinstance(s, str) else s
-            for s in specifications
-        )
-        if None in specifications:
-            raise ValueError("Invalid set of specifications: {}".format(specifications))
+def mark_specifications(*specifications, deprecated=False, strict=False):
+    specifications = frozenset(
+        Specifications.of_name(s) if isinstance(s, str) else s for s in specifications
+    )
+    if None in specifications:
+        raise ValueError("Invalid set of specifications: {}".format(specifications))
 
-        def decorator(f):
-            for specification in specifications:
-                f = getattr(pytest.mark, specification.value)(f)
-            if strict:
-                f = pytest.mark.strict(f)
-            return f
+    def decorator(f):
+        for specification in specifications:
+            f = getattr(pytest.mark, specification.value)(f)
+        if strict:
+            f = pytest.mark.strict(f)
+        if deprecated:
+            f = pytest.mark.deprecated(f)
+        return f
 
-        return decorator
+    return decorator

--- a/irctest/client_tests/test_cap.py
+++ b/irctest/client_tests/test_cap.py
@@ -3,12 +3,12 @@ from irctest.irc_utils.message_parser import Message
 
 
 class CapTestCase(cases.BaseClientTestCase, cases.ClientNegociationHelper):
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1", "IRCv3.2")
+    @cases.mark_specifications("IRCv3.1", "IRCv3.2")
     def testSendCap(self):
         """Send CAP LS 302 and read the result."""
         self.readCapLs()
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1", "IRCv3.2")
+    @cases.mark_specifications("IRCv3.1", "IRCv3.2")
     def testEmptyCapLs(self):
         """Empty result to CAP LS. Client should send CAP END."""
         m = self.negotiateCapabilities([])

--- a/irctest/server_tests/test_account_tag.py
+++ b/irctest/server_tests/test_account_tag.py
@@ -32,7 +32,7 @@ class AccountTagTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.sendLine(2, "CAP END")
         self.skipToWelcome(2)
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     @cases.OptionalityHelper.skipUnlessHasMechanism("PLAIN")
     def testPrivmsg(self):
         self.connectClient("foo", capabilities=["account-tag"], skip_if_cap_nak=True)

--- a/irctest/server_tests/test_away_notify.py
+++ b/irctest/server_tests/test_away_notify.py
@@ -6,7 +6,7 @@ from irctest import cases
 
 
 class AwayNotifyTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     def testAwayNotify(self):
         """Basic away-notify test."""
         self.connectClient("foo", capabilities=["away-notify"], skip_if_cap_nak=True)
@@ -31,7 +31,7 @@ class AwayNotifyTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         )
         self.assertEqual(awayNotify.params, ["i'm going away"])
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testAwayNotifyOnJoin(self):
         """The away-notify specification states:
         "Clients will be sent an AWAY message [...] when a user joins

--- a/irctest/server_tests/test_bouncer.py
+++ b/irctest/server_tests/test_bouncer.py
@@ -4,7 +4,7 @@ from irctest.numerics import ERR_NICKNAMEINUSE, RPL_WELCOME
 
 
 class Bouncer(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testBouncer(self):
         """Test basic bouncer functionality."""
         self.controller.registerUser(self, "observer", "observerpassword")

--- a/irctest/server_tests/test_cap.py
+++ b/irctest/server_tests/test_cap.py
@@ -2,7 +2,7 @@ from irctest import cases
 
 
 class CapTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     def testNoReq(self):
         """Test the server handles gracefully clients which do not send
         REQs.
@@ -22,7 +22,7 @@ class CapTestCase(cases.BaseServerTestCase):
             m, command="001", fail_msg="Expected 001 after sending CAP END, got {msg}."
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     def testReqUnavailable(self):
         """Test the server handles gracefully clients which request
         capabilities that are not available.
@@ -49,7 +49,7 @@ class CapTestCase(cases.BaseServerTestCase):
             m, command="001", fail_msg="Expected 001 after sending CAP END, got {msg}."
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     def testNakExactString(self):
         """“The argument of the NAK subcommand MUST consist of at least the
         first 100 characters of the capability list in the REQ subcommand which
@@ -72,7 +72,7 @@ class CapTestCase(cases.BaseServerTestCase):
             "sending “CAP REQ :foo qux bar baz qux quux”, but got {msg}.",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     def testNakWhole(self):
         """“The capability identifier set must be accepted as a whole, or
         rejected entirely.”
@@ -123,7 +123,7 @@ class CapTestCase(cases.BaseServerTestCase):
             "sending “CAP REQ :multi-prefix”, but got {msg}.",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testCapRemovalByClient(self):
         """Test CAP LIST and removal of caps via CAP REQ :-tagname."""
         self.addClient(1)

--- a/irctest/server_tests/test_channel_forward.py
+++ b/irctest/server_tests/test_channel_forward.py
@@ -14,7 +14,7 @@ MODERN_CAPS = [
 class ChannelForwarding(cases.BaseServerTestCase):
     """Test the +f channel forwarding mode."""
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testChannelForwarding(self):
         self.connectClient("bar", name="bar", capabilities=MODERN_CAPS)
         self.connectClient("baz", name="baz", capabilities=MODERN_CAPS)

--- a/irctest/server_tests/test_channel_operations.py
+++ b/irctest/server_tests/test_channel_operations.py
@@ -33,9 +33,7 @@ MODERN_CAPS = [
 
 
 class JoinTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification(
-        "RFC1459", "RFC2812", strict=True
-    )
+    @cases.mark_specifications("RFC1459", "RFC2812", strict=True)
     def testJoinAllMessages(self):
         """“If a JOIN is successful, the user receives a JOIN message as
         confirmation and is then sent the channel's topic (using RPL_TOPIC) and
@@ -59,7 +57,7 @@ class JoinTestCase(cases.BaseServerTestCase):
             ),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testJoinNamreply(self):
         """“353    RPL_NAMREPLY
             "( "=" / "*" / "@" ) <channel>
@@ -102,7 +100,7 @@ class JoinTestCase(cases.BaseServerTestCase):
                     "{msg}",
                 )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testPartNotInEmptyChannel(self):
         """“442     ERR_NOTONCHANNEL
             "<channel> :You're not on that channel"
@@ -138,7 +136,7 @@ class JoinTestCase(cases.BaseServerTestCase):
             "one is not on, but got: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testPartNotInNonEmptyChannel(self):
         self.connectClient("foo")
         self.connectClient("bar")
@@ -198,7 +196,7 @@ class JoinTestCase(cases.BaseServerTestCase):
                     "{msg}",
                 )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testNormalPart(self):
         self.connectClient("bar")
         self.sendLine(1, "JOIN #chan")
@@ -222,7 +220,7 @@ class JoinTestCase(cases.BaseServerTestCase):
         m = self.getMessage(2)
         self.assertMessageEqual(m, command="PART", params=["#chan", "bye everyone"])
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testTopic(self):
         """“Once a user has joined a channel, he receives information about
         all commands his server receives affecting the channel.  This
@@ -258,7 +256,7 @@ class JoinTestCase(cases.BaseServerTestCase):
         m = self.getMessage(2)
         self.assertMessageEqual(m, command="TOPIC", params=["#chan", "T0P1C"])
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testTopicMode(self):
         """“Once a user has joined a channel, he receives information about
         all commands his server receives affecting the channel.  This
@@ -303,7 +301,7 @@ class JoinTestCase(cases.BaseServerTestCase):
         m = self.getMessage(1)
         self.assertMessageEqual(m, command="TOPIC", params=["#chan", "T0P1C"])
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testTopicNonexistentChannel(self):
         """RFC2812 specifies ERR_NOTONCHANNEL as the correct response to TOPIC
         on a nonexistent channel. The modern spec prefers ERR_NOSUCHCHANNEL.
@@ -317,7 +315,7 @@ class JoinTestCase(cases.BaseServerTestCase):
         # either 403 ERR_NOSUCHCHANNEL or 443 ERR_NOTONCHANNEL
         self.assertIn(m.command, ("403", "443"))
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testUnsetTopicResponses(self):
         """Test various cases related to RPL_NOTOPIC with set and unset topics."""
         self.connectClient("bar")
@@ -355,7 +353,7 @@ class JoinTestCase(cases.BaseServerTestCase):
         # topic is once again unset, shouldn't send RPL_NOTOPIC on initial join
         self.assertNotIn(RPL_NOTOPIC, [m.command for m in messages])
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testListEmpty(self):
         """<https://tools.ietf.org/html/rfc1459#section-4.2.6>
         <https://tools.ietf.org/html/rfc2812#section-3.2.6>
@@ -380,7 +378,7 @@ class JoinTestCase(cases.BaseServerTestCase):
             "or 323 (RPL_LISTEND), or but: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testListOne(self):
         """When a channel exists, LIST should get it in a reply.
         <https://tools.ietf.org/html/rfc1459#section-4.2.6>
@@ -421,7 +419,7 @@ class JoinTestCase(cases.BaseServerTestCase):
             "or 323 (RPL_LISTEND), or but: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testKickSendsMessages(self):
         """“Once a user has joined a channel, he receives information about
         all commands his server receives affecting the channel.  This
@@ -459,7 +457,7 @@ class JoinTestCase(cases.BaseServerTestCase):
         m = self.getMessage(3)
         self.assertMessageEqual(m, command="KICK", params=["#chan", "bar", "bye"])
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testKickPrivileges(self):
         """Test who has the ability to kick / what error codes are sent
         for invalid kicks."""
@@ -516,7 +514,7 @@ class JoinTestCase(cases.BaseServerTestCase):
             f"unexpected kick targets: {kick_targets}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testKickNonexistentChannel(self):
         """“Kick command [...] Numeric replies: [...] ERR_NOSUCHCHANNEL."""
         self.connectClient("foo")
@@ -525,7 +523,7 @@ class JoinTestCase(cases.BaseServerTestCase):
         # should return ERR_NOSUCHCHANNEL
         self.assertMessageEqual(m, command="403")
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testDoubleKickMessages(self):
         """“The server MUST NOT send KICK messages with multiple channels or
         users to clients.  This is necessarily to maintain backward
@@ -587,7 +585,7 @@ class JoinTestCase(cases.BaseServerTestCase):
                 )
             )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC-deprecated")
+    @cases.mark_specifications("RFC1459", "RFC2812", deprecated=True)
     def testInviteNonExistingChannelTransmitted(self):
         """“There is no requirement that the channel the target user is being
         invited to must exist or be a valid channel.”
@@ -620,7 +618,7 @@ class JoinTestCase(cases.BaseServerTestCase):
             "got this instead: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC-deprecated")
+    @cases.mark_specifications("RFC1459", "RFC2812", deprecated=True)
     def testInviteNonExistingChannelEchoed(self):
         """“There is no requirement that the channel the target user is being
         invited to must exist or be a valid channel.”
@@ -655,9 +653,7 @@ class JoinTestCase(cases.BaseServerTestCase):
 
 class testChannelCaseSensitivity(cases.BaseServerTestCase):
     def _testChannelsEquivalent(casemapping, name1, name2):
-        @cases.SpecificationSelector.requiredBySpecification(
-            "RFC1459", "RFC2812", strict=True
-        )
+        @cases.mark_specifications("RFC1459", "RFC2812", strict=True)
         def f(self):
             self.connectClient("foo")
             self.connectClient("bar")
@@ -679,9 +675,7 @@ class testChannelCaseSensitivity(cases.BaseServerTestCase):
         return f
 
     def _testChannelsNotEquivalent(casemapping, name1, name2):
-        @cases.SpecificationSelector.requiredBySpecification(
-            "RFC1459", "RFC2812", strict=True
-        )
+        @cases.mark_specifications("RFC1459", "RFC2812", strict=True)
         def f(self):
             self.connectClient("foo")
             self.connectClient("bar")
@@ -718,7 +712,7 @@ class testChannelCaseSensitivity(cases.BaseServerTestCase):
 
 
 class InviteTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testInvites(self):
         """Test some basic functionality related to INVITE and the +i mode."""
         self.connectClient("foo")
@@ -749,7 +743,7 @@ class InviteTestCase(cases.BaseServerTestCase):
 
 
 class ChannelQuitTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testQuit(self):
         """“Once a user has joined a channel, he receives information about
         all commands his server receives affecting the channel.  This
@@ -772,7 +766,7 @@ class ChannelQuitTestCase(cases.BaseServerTestCase):
 
 
 class NoCTCPTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testQuit(self):
         self.connectClient("bar")
         self.joinChannel(1, "#chan")
@@ -800,7 +794,7 @@ class NoCTCPTestCase(cases.BaseServerTestCase):
 
 
 class KeyTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testKeyNormal(self):
         self.connectClient("bar")
         self.joinChannel(1, "#chan")
@@ -818,7 +812,7 @@ class KeyTestCase(cases.BaseServerTestCase):
         reply = self.getMessages(2)
         self.assertMessageEqual(reply[0], command="JOIN", params=["#chan"])
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testKeyValidation(self):
         # oragono issue #1021
         self.connectClient("bar")
@@ -830,7 +824,7 @@ class KeyTestCase(cases.BaseServerTestCase):
 
 
 class AuditoriumTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testAuditorium(self):
         self.connectClient("bar", name="bar", capabilities=MODERN_CAPS)
         self.joinChannel("bar", "#auditorium")
@@ -934,7 +928,7 @@ class AuditoriumTestCase(cases.BaseServerTestCase):
 
 
 class TopicPrivileges(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testTopicPrivileges(self):
         # test the +t channel mode, which prevents unprivileged users
         # from changing the topic
@@ -984,7 +978,7 @@ class TopicPrivileges(cases.BaseServerTestCase):
 
 
 class ModeratedMode(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testModeratedMode(self):
         # test the +m channel mode
         self.connectClient("chanop", name="chanop")
@@ -1019,7 +1013,7 @@ class ModeratedMode(cases.BaseServerTestCase):
 
 
 class OpModerated(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testOpModerated(self):
         # test the +U channel mode
         self.connectClient("chanop", name="chanop", capabilities=MODERN_CAPS)
@@ -1075,7 +1069,7 @@ class OpModerated(cases.BaseServerTestCase):
 
 
 class MuteExtban(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testISupport(self):
         isupport = self.getISupport()
         token = isupport["EXTBAN"]
@@ -1084,7 +1078,7 @@ class MuteExtban(cases.BaseServerTestCase):
         self.assertEqual(comma, ",")
         self.assertIn("m", types)
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testMuteExtban(self):
         clients = ("chanop", "bar", "qux")
 
@@ -1165,7 +1159,7 @@ class MuteExtban(cases.BaseServerTestCase):
             [msg for msg in replies if msg.command == "PRIVMSG"],
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testIssue1370(self):
         # regression test for oragono #1370: mutes not correctly enforced against
         # users with capital letters in their NUH

--- a/irctest/server_tests/test_channel_rename.py
+++ b/irctest/server_tests/test_channel_rename.py
@@ -15,7 +15,7 @@ RENAME_CAP = "draft/channel-rename"
 class ChannelRename(cases.BaseServerTestCase):
     """Basic tests for channel-rename."""
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testChannelRename(self):
         self.connectClient("bar", name="bar", capabilities=MODERN_CAPS + [RENAME_CAP])
         self.connectClient("baz", name="baz", capabilities=MODERN_CAPS)

--- a/irctest/server_tests/test_chathistory.py
+++ b/irctest/server_tests/test_chathistory.py
@@ -37,7 +37,7 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
     def config():
         return {"chathistory": True}
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testInvalidTargets(self):
         bar, pw = random_name("bar"), random_name("pw")
         self.controller.registerUser(self, bar, pw)
@@ -74,7 +74,7 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
         self.assertEqual(msgs[0].command, "FAIL")
         self.assertEqual(msgs[0].params[:2], ["CHATHISTORY", "INVALID_TARGET"])
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testMessagesToSelf(self):
         bar, pw = random_name("bar"), random_name("pw")
         self.controller.registerUser(self, bar, pw)
@@ -139,7 +139,7 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
         self.assertEqual(len(set(msg.msgid for msg in echo_messages)), num_messages)
         self.assertEqual(len(set(msg.time for msg in echo_messages)), num_messages)
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testChathistory(self):
         self.connectClient(
             "bar",
@@ -167,7 +167,7 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
         self.validate_echo_messages(NUM_MESSAGES, echo_messages)
         self.validate_chathistory(echo_messages, 1, chname)
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testChathistoryDMs(self):
         c1 = secrets.token_hex(12)
         c2 = secrets.token_hex(12)
@@ -479,7 +479,7 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
         result = validate_chathistory_batch(self.getMessages(user))
         self.assertIn(echo_messages[7], result)
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testChathistoryTagmsg(self):
         c1 = secrets.token_hex(12)
         c2 = secrets.token_hex(12)
@@ -574,7 +574,7 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
         ]
         self.assertEqual(len(history_tagmsgs), 0)
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testChathistoryDMClientOnlyTags(self):
         # regression test for Oragono #1411
         c1 = secrets.token_hex(12)

--- a/irctest/server_tests/test_confusables.py
+++ b/irctest/server_tests/test_confusables.py
@@ -11,7 +11,7 @@ class ConfusablesTestCase(cases.BaseServerTestCase):
             )
         }
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testConfusableNicks(self):
         self.controller.registerUser(self, "evan", "sesame")
 

--- a/irctest/server_tests/test_connection_registration.py
+++ b/irctest/server_tests/test_connection_registration.py
@@ -10,7 +10,7 @@ from irctest.client_mock import ConnectionClosed
 class PasswordedConnectionRegistrationTestCase(cases.BaseServerTestCase):
     password = "testpassword"
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testPassBeforeNickuser(self):
         self.addClient()
         self.sendLine(1, "PASS {}".format(self.password))
@@ -24,7 +24,7 @@ class PasswordedConnectionRegistrationTestCase(cases.BaseServerTestCase):
             fail_msg="Did not get 001 after correct PASS+NICK+USER: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testNoPassword(self):
         self.addClient()
         self.sendLine(1, "NICK foo")
@@ -34,7 +34,7 @@ class PasswordedConnectionRegistrationTestCase(cases.BaseServerTestCase):
             m.command, "001", msg="Got 001 after NICK+USER but missing PASS"
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testWrongPassword(self):
         self.addClient()
         self.sendLine(1, "PASS {}".format(self.password + "garbage"))
@@ -45,9 +45,7 @@ class PasswordedConnectionRegistrationTestCase(cases.BaseServerTestCase):
             m.command, "001", msg="Got 001 after NICK+USER but incorrect PASS"
         )
 
-    @cases.SpecificationSelector.requiredBySpecification(
-        "RFC1459", "RFC2812", strict=True
-    )
+    @cases.mark_specifications("RFC1459", "RFC2812", strict=True)
     def testPassAfterNickuser(self):
         """“The password can and must be set before any attempt to register
         the connection is made.”
@@ -68,7 +66,7 @@ class PasswordedConnectionRegistrationTestCase(cases.BaseServerTestCase):
 
 
 class ConnectionRegistrationTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459")
+    @cases.mark_specifications("RFC1459")
     def testQuitDisconnects(self):
         """“The server must close the connection to a client which sends a
         QUIT message.”
@@ -81,7 +79,7 @@ class ConnectionRegistrationTestCase(cases.BaseServerTestCase):
             self.getMessages(1)  # Fetch remaining messages
             self.getMessages(1)
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testQuitErrors(self):
         """“A client session is terminated with a quit message.  The server
         acknowledges this by sending an ERROR message to the client.”
@@ -130,7 +128,7 @@ class ConnectionRegistrationTestCase(cases.BaseServerTestCase):
             "both got 001.",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1", "IRCv3.2")
+    @cases.mark_specifications("IRCv3.1", "IRCv3.2")
     def testIrc301CapLs(self):
         """IRCv3.1: “The LS subcommand is used to list the capabilities
         supported by the server. The client should send an LS subcommand with
@@ -158,7 +156,7 @@ class ConnectionRegistrationTestCase(cases.BaseServerTestCase):
             "request: {}".format(m),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     def testEmptyCapList(self):
         """“If no capabilities are active, an empty parameter must be sent.”
         -- <http://ircv3.net/specs/core/capability-negotiation-3.1.html#the-cap-list-subcommand>

--- a/irctest/server_tests/test_echo_message.py
+++ b/irctest/server_tests/test_echo_message.py
@@ -8,7 +8,7 @@ from irctest.irc_utils.junkdrawer import random_name
 
 
 class DMEchoMessageTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testDirectMessageEcho(self):
         bar = random_name("bar")
         self.connectClient(
@@ -58,7 +58,7 @@ class DMEchoMessageTestCase(cases.BaseServerTestCase):
 
 class EchoMessageTestCase(cases.BaseServerTestCase):
     def _testEchoMessage(command, solo, server_time):
-        @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+        @cases.mark_specifications("IRCv3.2")
         def f(self):
             """<http://ircv3.net/specs/extensions/echo-message-3.2.html>"""
             self.addClient()

--- a/irctest/server_tests/test_extended_join.py
+++ b/irctest/server_tests/test_extended_join.py
@@ -32,7 +32,7 @@ class MetadataTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.sendLine(2, "CAP END")
         self.skipToWelcome(2)
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     def testNotLoggedIn(self):
         self.connectClient("foo", capabilities=["extended-join"], skip_if_cap_nak=True)
         self.joinChannel(1, "#chan")
@@ -47,7 +47,7 @@ class MetadataTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
             "unregistered user joined, got: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     @cases.OptionalityHelper.skipUnlessHasMechanism("PLAIN")
     def testLoggedIn(self):
         self.connectClient("foo", capabilities=["extended-join"], skip_if_cap_nak=True)

--- a/irctest/server_tests/test_labeled_responses.py
+++ b/irctest/server_tests/test_labeled_responses.py
@@ -8,7 +8,7 @@ from irctest import cases
 
 
 class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testLabeledPrivmsgResponsesToMultipleClients(self):
         self.connectClient(
             "foo",
@@ -92,7 +92,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
             m, command="BATCH", fail_msg="No BATCH echo received after sending one out"
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testLabeledPrivmsgResponsesToClient(self):
         self.connectClient(
             "foo",
@@ -152,7 +152,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
             ),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testLabeledPrivmsgResponsesToChannel(self):
         self.connectClient(
             "foo",
@@ -220,7 +220,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
             ),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testLabeledPrivmsgResponsesToSelf(self):
         self.connectClient(
             "foo",
@@ -263,7 +263,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
             ).format(number_of_labels),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testLabeledNoticeResponsesToClient(self):
         self.connectClient(
             "foo",
@@ -323,7 +323,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
             ),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testLabeledNoticeResponsesToChannel(self):
         self.connectClient(
             "foo",
@@ -391,7 +391,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
             ),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testLabeledNoticeResponsesToSelf(self):
         self.connectClient(
             "foo",
@@ -432,7 +432,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
             ).format(number_of_labels),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testLabeledTagMsgResponsesToClient(self):
         self.connectClient(
             "foo",
@@ -540,7 +540,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
             fail_msg="React tag wasn't the same on the source user's TAGMSG: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testLabeledTagMsgResponsesToChannel(self):
         self.connectClient(
             "foo",
@@ -606,7 +606,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
             ),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testLabeledTagMsgResponsesToSelf(self):
         self.connectClient(
             "foo",
@@ -647,7 +647,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
             ).format(number_of_labels),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testBatchedJoinMessages(self):
         self.connectClient(
             "bar",
@@ -687,7 +687,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
         for message in m[1:-1]:
             self.assertEqual(message.tags.get("batch"), batch_id)
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testNoBatchForSingleMessage(self):
         self.connectClient(
             "bar",
@@ -706,7 +706,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
         # check the label
         self.assertEqual(m.tags.get("label"), "98765")
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testEmptyBatchForNoResponse(self):
         self.connectClient(
             "bar",

--- a/irctest/server_tests/test_lusers.py
+++ b/irctest/server_tests/test_lusers.py
@@ -87,7 +87,7 @@ class LusersTestCase(cases.BaseServerTestCase):
 
 
 class BasicLusersTest(LusersTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testLusers(self):
         self.connectClient("bar", name="bar")
         lusers = self.getLusers("bar")
@@ -125,7 +125,7 @@ class BasicLusersTest(LusersTestCase):
 
 
 class LusersUnregisteredTestCase(LusersTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testLusers(self):
         self.doLusersTest()
 
@@ -218,7 +218,7 @@ class LusersUnregisteredDefaultInvisibleTest(LusersUnregisteredTestCase):
             )
         }
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testLusers(self):
         self.doLusersTest()
         lusers = self.getLusers("bar")
@@ -232,7 +232,7 @@ class LusersUnregisteredDefaultInvisibleTest(LusersUnregisteredTestCase):
 
 
 class LuserOpersTest(LusersTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testLuserOpers(self):
         self.connectClient("bar", name="bar")
         lusers = self.getLusers("bar")
@@ -310,7 +310,7 @@ class OragonoInvisibleDefaultTest(LusersTestCase):
             )
         }
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testLusers(self):
         self.connectClient("bar", name="bar")
         lusers = self.getLusers("bar")

--- a/irctest/server_tests/test_message_tags.py
+++ b/irctest/server_tests/test_message_tags.py
@@ -8,7 +8,7 @@ from irctest.numerics import ERR_INPUTTOOLONG
 
 
 class MessageTagsTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
-    @cases.SpecificationSelector.requiredBySpecification("message-tags")
+    @cases.mark_specifications("message-tags")
     def testBasic(self):
         def getAllMessages():
             for name in ["alice", "bob", "carol", "dave"]:
@@ -87,7 +87,7 @@ class MessageTagsTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.assertTrue(alice_msg.tags["msgid"])
         self.assertEqual(alice_msg.tags["msgid"], bob_msg.tags["msgid"])
 
-    @cases.SpecificationSelector.requiredBySpecification("message-tags")
+    @cases.mark_specifications("message-tags")
     def testLengthLimits(self):
         self.connectClient(
             "alice",

--- a/irctest/server_tests/test_messages.py
+++ b/irctest/server_tests/test_messages.py
@@ -8,7 +8,7 @@ from irctest.numerics import ERR_INPUTTOOLONG
 
 
 class PrivmsgTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testPrivmsg(self):
         """<https://tools.ietf.org/html/rfc2812#section-3.3.1>"""
         self.connectClient("foo")
@@ -24,7 +24,7 @@ class PrivmsgTestCase(cases.BaseServerTestCase):
             pms[0], command="PRIVMSG", params=["#chan", "hello there"]
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testPrivmsgNonexistentChannel(self):
         """<https://tools.ietf.org/html/rfc2812#section-3.3.1>"""
         self.connectClient("foo")
@@ -35,7 +35,7 @@ class PrivmsgTestCase(cases.BaseServerTestCase):
 
 
 class NoticeTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testNotice(self):
         """<https://tools.ietf.org/html/rfc2812#section-3.3.2>"""
         self.connectClient("foo")
@@ -51,7 +51,7 @@ class NoticeTestCase(cases.BaseServerTestCase):
             notices[0], command="NOTICE", params=["#chan", "hello there"]
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459", "RFC2812")
+    @cases.mark_specifications("RFC1459", "RFC2812")
     def testNoticeNonexistentChannel(self):
         """
         'automatic replies MUST NEVER be sent in response to a NOTICE message.
@@ -65,7 +65,7 @@ class NoticeTestCase(cases.BaseServerTestCase):
 
 
 class TagsTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testLineTooLong(self):
         self.connectClient("bar")
         self.joinChannel(1, "#xyz")

--- a/irctest/server_tests/test_metadata.py
+++ b/irctest/server_tests/test_metadata.py
@@ -10,7 +10,7 @@ class MetadataTestCase(cases.BaseServerTestCase):
     valid_metadata_keys = {"valid_key1", "valid_key2"}
     invalid_metadata_keys = {"invalid_key1", "invalid_key2"}
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2-deprecated")
+    @cases.mark_specifications("IRCv3.2", deprecated=True)
     def testInIsupport(self):
         """“If METADATA is supported, it MUST be specified in RPL_ISUPPORT
         using the METADATA key.”
@@ -33,7 +33,7 @@ class MetadataTestCase(cases.BaseServerTestCase):
         )
         self.getMessages(1)
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2-deprecated")
+    @cases.mark_specifications("IRCv3.2", deprecated=True)
     def testGetOneUnsetValid(self):
         """<http://ircv3.net/specs/core/metadata-3.2.html#metadata-get>"""
         self.connectClient("foo")
@@ -46,7 +46,7 @@ class MetadataTestCase(cases.BaseServerTestCase):
             "request to an unset valid METADATA key.",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2-deprecated")
+    @cases.mark_specifications("IRCv3.2", deprecated=True)
     def testGetTwoUnsetValid(self):
         """“Multiple keys may be given. The response will be either RPL_KEYVALUE,
         ERR_KEYINVALID or ERR_NOMATCHINGKEY for every key in order.”
@@ -83,7 +83,7 @@ class MetadataTestCase(cases.BaseServerTestCase):
             "did not respond to valid_key2 as second response: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2-deprecated")
+    @cases.mark_specifications("IRCv3.2", deprecated=True)
     def testListNoSet(self):
         """“This subcommand MUST list all currently-set metadata keys along
         with their values. The response will be zero or more RPL_KEYVALUE
@@ -100,7 +100,7 @@ class MetadataTestCase(cases.BaseServerTestCase):
             "762 (RPL_METADATAEND) but: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2-deprecated")
+    @cases.mark_specifications("IRCv3.2", deprecated=True)
     def testListInvalidTarget(self):
         """“In case of invalid target RPL_METADATAEND MUST NOT be sent.”
         -- <http://ircv3.net/specs/core/metadata-3.2.html#metadata-list>
@@ -187,13 +187,13 @@ class MetadataTestCase(cases.BaseServerTestCase):
         self.assertSetValue(target, key, value, displayable_value)
         self.assertGetValue(target, key, value, displayable_value)
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2-deprecated")
+    @cases.mark_specifications("IRCv3.2", deprecated=True)
     def testSetGetValid(self):
         """<http://ircv3.net/specs/core/metadata-3.2.html>"""
         self.connectClient("foo")
         self.assertSetGetValue("*", "valid_key1", "myvalue")
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2-deprecated")
+    @cases.mark_specifications("IRCv3.2", deprecated=True)
     def testSetGetZeroCharInValue(self):
         """“Values are unrestricted, except that they MUST be UTF-8.”
         -- <http://ircv3.net/specs/core/metadata-3.2.html#metadata-restrictions>
@@ -201,7 +201,7 @@ class MetadataTestCase(cases.BaseServerTestCase):
         self.connectClient("foo")
         self.assertSetGetValue("*", "valid_key1", "zero->\0<-zero", "zero->\\0<-zero")
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2-deprecated")
+    @cases.mark_specifications("IRCv3.2", deprecated=True)
     def testSetGetHeartInValue(self):
         """“Values are unrestricted, except that they MUST be UTF-8.”
         -- <http://ircv3.net/specs/core/metadata-3.2.html#metadata-restrictions>
@@ -215,7 +215,7 @@ class MetadataTestCase(cases.BaseServerTestCase):
             "zero->{}<-zero".format(heart.encode()),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2-deprecated")
+    @cases.mark_specifications("IRCv3.2", deprecated=True)
     def testSetInvalidUtf8(self):
         """“Values are unrestricted, except that they MUST be UTF-8.”
         -- <http://ircv3.net/specs/core/metadata-3.2.html#metadata-restrictions>

--- a/irctest/server_tests/test_monitor.py
+++ b/irctest/server_tests/test_monitor.py
@@ -66,7 +66,7 @@ class MonitorTestCase(cases.BaseServerTestCase):
             extra_format=(nick,),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testMonitorOneDisconnected(self):
         """“If any of the targets being added are online, the server will
         generate RPL_MONONLINE numerics listing those targets that are
@@ -86,7 +86,7 @@ class MonitorTestCase(cases.BaseServerTestCase):
             pass
         self.assertMonoffline(1, "bar")
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testMonitorOneConnection(self):
         self.connectClient("foo")
         self.check_server_support()
@@ -95,7 +95,7 @@ class MonitorTestCase(cases.BaseServerTestCase):
         self.connectClient("bar")
         self.assertMononline(1, "bar")
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testMonitorOneConnected(self):
         """“If any of the targets being added are offline, the server will
         generate RPL_MONOFFLINE numerics listing those targets that are
@@ -114,7 +114,7 @@ class MonitorTestCase(cases.BaseServerTestCase):
             pass
         self.assertMonoffline(1, "bar")
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testMonitorOneConnectionWithQuit(self):
         self.connectClient("foo")
         self.check_server_support()
@@ -130,7 +130,7 @@ class MonitorTestCase(cases.BaseServerTestCase):
         self.connectClient("bar")
         self.assertMononline(1, "bar")
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testMonitorConnectedAndDisconnected(self):
         """“If any of the targets being added are online, the server will
         generate RPL_MONONLINE numerics listing those targets that are
@@ -185,7 +185,7 @@ class MonitorTestCase(cases.BaseServerTestCase):
             "“MONITOR + bar,baz” and “baz” is disconnected: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testUnmonitor(self):
         self.connectClient("foo")
         self.check_server_support()
@@ -210,7 +210,7 @@ class MonitorTestCase(cases.BaseServerTestCase):
             fail_msg="Got messages after disconnection of unmonitored " "nick: {got}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testMonitorForbidsMasks(self):
         """“The MONITOR implementation also enhances user privacy by
         disallowing subscription to hostmasks, allowing users to avoid
@@ -247,7 +247,7 @@ class MonitorTestCase(cases.BaseServerTestCase):
                 "was requested via hostmask connected: {}".format(m)
             )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testTwoMonitoringOneRemove(self):
         """Tests the following scenario:
         * foo MONITORs qux
@@ -286,7 +286,7 @@ class MonitorTestCase(cases.BaseServerTestCase):
             extra_format=(messages,),
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testMonitorList(self):
         def checkMonitorSubjects(messages, client_nick, expected_targets):
             # collect all the RPL_MONLIST nicks into a set:
@@ -320,7 +320,7 @@ class MonitorTestCase(cases.BaseServerTestCase):
         self.sendLine(1, "MONITOR L")
         checkMonitorSubjects(self.getMessages(1), "bar", {"bazbat"})
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testNickChange(self):
         # see oragono issue #1076: nickname changes must trigger RPL_MONOFFLINE
         self.connectClient("bar")

--- a/irctest/server_tests/test_multi_prefix.py
+++ b/irctest/server_tests/test_multi_prefix.py
@@ -7,7 +7,7 @@ from irctest import cases
 
 
 class MultiPrefixTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     def testMultiPrefix(self):
         """“When requested, the multi-prefix client capability will cause the
         IRC server to send all possible prefixes which apply to a user in NAMES

--- a/irctest/server_tests/test_multiline.py
+++ b/irctest/server_tests/test_multiline.py
@@ -12,7 +12,7 @@ base_caps = ["message-tags", "batch", "echo-message", "server-time", "labeled-re
 
 
 class MultilineTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
-    @cases.SpecificationSelector.requiredBySpecification("multiline")
+    @cases.mark_specifications("multiline")
     def testBasic(self):
         self.connectClient(
             "alice", capabilities=(base_caps + [CAP_NAME]), skip_if_cap_nak=True
@@ -79,7 +79,7 @@ class MultilineTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
             self.assertNotIn(CONCAT_TAG, msg.tags)
         self.assertEqual(relayed_fmsgids, [msgid] + [None] * (len(fallback_relay) - 1))
 
-    @cases.SpecificationSelector.requiredBySpecification("multiline")
+    @cases.mark_specifications("multiline")
     def testBlankLines(self):
         self.connectClient(
             "alice", capabilities=(base_caps + [CAP_NAME]), skip_if_cap_nak=True

--- a/irctest/server_tests/test_readq.py
+++ b/irctest/server_tests/test_readq.py
@@ -4,14 +4,14 @@ from irctest import cases
 class ReadqTestCase(cases.BaseServerTestCase):
     """Test responses to DoS attacks using long lines."""
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testReadqTags(self):
         self.connectClient("mallory", name="mallory", capabilities=["message-tags"])
         self.joinChannel("mallory", "#test")
         self.sendLine("mallory", "PRIVMSG #test " + "a" * 16384)
         self.assertDisconnected("mallory")
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testReadqNoTags(self):
         self.connectClient("mallory", name="mallory")
         self.joinChannel("mallory", "#test")

--- a/irctest/server_tests/test_register_verify.py
+++ b/irctest/server_tests/test_register_verify.py
@@ -12,7 +12,7 @@ class TestRegisterBeforeConnect(cases.BaseServerTestCase):
             )
         }
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testBeforeConnect(self):
         self.addClient("bar")
         self.sendLine("bar", "CAP LS 302")
@@ -35,7 +35,7 @@ class TestRegisterBeforeConnectDisallowed(cases.BaseServerTestCase):
             )
         }
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testBeforeConnect(self):
         self.addClient("bar")
         self.sendLine("bar", "CAP LS 302")
@@ -66,7 +66,7 @@ class TestRegisterEmailVerified(cases.BaseServerTestCase):
             )
         }
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testBeforeConnect(self):
         self.addClient("bar")
         self.sendLine("bar", "CAP LS 302")
@@ -82,7 +82,7 @@ class TestRegisterEmailVerified(cases.BaseServerTestCase):
         fail_response = [msg for msg in msgs if msg.command == "FAIL"][0]
         self.assertEqual(fail_response.params[:2], ["REGISTER", "INVALID_EMAIL"])
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testAfterConnect(self):
         self.connectClient("bar", name="bar")
         self.sendLine("bar", "REGISTER * shivarampassphrase")
@@ -100,7 +100,7 @@ class TestRegisterNoLandGrabs(cases.BaseServerTestCase):
             )
         }
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testBeforeConnect(self):
         # have an anonymous client take the 'root' username:
         self.connectClient("root", name="root")

--- a/irctest/server_tests/test_regressions.py
+++ b/irctest/server_tests/test_regressions.py
@@ -7,7 +7,7 @@ from irctest.numerics import ERR_ERRONEUSNICKNAME, ERR_NICKNAMEINUSE, RPL_WELCOM
 
 
 class RegressionsTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459")
+    @cases.mark_specifications("RFC1459")
     def testFailedNickChange(self):
         # see oragono commit d0ded906d4ac8f
         self.connectClient("alice")
@@ -27,7 +27,7 @@ class RegressionsTestCase(cases.BaseServerTestCase):
         self.assertEqual(len(ms), 1)
         self.assertMessageEqual(ms[0], command="PRIVMSG", params=["bob", "hi"])
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459")
+    @cases.mark_specifications("RFC1459")
     def testCaseChanges(self):
         self.connectClient("alice")
         self.joinChannel(1, "#test")
@@ -52,7 +52,7 @@ class RegressionsTestCase(cases.BaseServerTestCase):
         ms = self.getMessages(2)
         self.assertEqual(ms, [])
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.2")
+    @cases.mark_specifications("IRCv3.2")
     def testTagCap(self):
         # regression test for oragono #754
         self.connectClient(
@@ -93,7 +93,7 @@ class RegressionsTestCase(cases.BaseServerTestCase):
         self.assertMessageEqual(ms[0], command="PRIVMSG", params=["bob", "hey again"])
         self.assertEqual(ms[0].tags.get("+draft/reply"), "tbxqauh9nykrtpa3n6icd9whan")
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459")
+    @cases.mark_specifications("RFC1459")
     def testStarNick(self):
         self.addClient(1)
         self.sendLine(1, "NICK *")
@@ -111,7 +111,7 @@ class RegressionsTestCase(cases.BaseServerTestCase):
         self.assertNotIn(ERR_ERRONEUSNICKNAME, replies)
         self.assertIn(RPL_WELCOME, replies)
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459")
+    @cases.mark_specifications("RFC1459")
     def testEmptyNick(self):
         self.addClient(1)
         self.sendLine(1, "NICK :")
@@ -121,7 +121,7 @@ class RegressionsTestCase(cases.BaseServerTestCase):
             replies = set(msg.command for msg in self.getMessages(1, synchronize=False))
         self.assertNotIn(RPL_WELCOME, replies)
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459")
+    @cases.mark_specifications("RFC1459")
     def testNickRelease(self):
         # regression test for oragono #1252
         self.connectClient("alice")
@@ -138,7 +138,7 @@ class RegressionsTestCase(cases.BaseServerTestCase):
         self.assertNotIn(ERR_NICKNAMEINUSE, replies)
         self.assertIn(RPL_WELCOME, replies)
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459")
+    @cases.mark_specifications("RFC1459")
     def testNickReleaseQuit(self):
         self.connectClient("alice")
         self.getMessages(1)
@@ -161,7 +161,7 @@ class RegressionsTestCase(cases.BaseServerTestCase):
         self.assertNotIn(ERR_NICKNAMEINUSE, replies)
         self.assertIn(RPL_WELCOME, replies)
 
-    @cases.SpecificationSelector.requiredBySpecification("RFC1459")
+    @cases.mark_specifications("RFC1459")
     def testNickReleaseUnregistered(self):
         self.addClient(1)
         self.sendLine(1, "NICK alice")

--- a/irctest/server_tests/test_relaymsg.py
+++ b/irctest/server_tests/test_relaymsg.py
@@ -11,7 +11,7 @@ class RelaymsgTestCase(cases.BaseServerTestCase):
     def config():
         return {"chathistory": True}
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testRelaymsg(self):
         self.connectClient(
             "baz",

--- a/irctest/server_tests/test_resume.py
+++ b/irctest/server_tests/test_resume.py
@@ -11,7 +11,7 @@ ANCIENT_TIMESTAMP = "2006-01-02T15:04:05.999Z"
 
 
 class ResumeTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testNoResumeByDefault(self):
         self.connectClient(
             "bar", capabilities=["batch", "echo-message", "labeled-response"]
@@ -24,7 +24,7 @@ class ResumeTestCase(cases.BaseServerTestCase):
             "should not see RESUME messages unless explicitly negotiated",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testResume(self):
         chname = "#" + secrets.token_hex(12)
         self.connectClient(
@@ -175,7 +175,7 @@ class ResumeTestCase(cases.BaseServerTestCase):
             resume_messages[1], command="RESUME", params=["SUCCESS", "baz"]
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testBRB(self):
         chname = "#" + secrets.token_hex(12)
         self.connectClient(

--- a/irctest/server_tests/test_roleplay.py
+++ b/irctest/server_tests/test_roleplay.py
@@ -8,7 +8,7 @@ class RoleplayTestCase(cases.BaseServerTestCase):
     def config():
         return {"oragono_roleplay": True}
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testRoleplay(self):
         bar = random_name("bar")
         qux = random_name("qux")

--- a/irctest/server_tests/test_sasl.py
+++ b/irctest/server_tests/test_sasl.py
@@ -9,7 +9,7 @@ class RegistrationTestCase(cases.BaseServerTestCase):
 
 
 class SaslTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     @cases.OptionalityHelper.skipUnlessHasMechanism("PLAIN")
     def testPlain(self):
         """PLAIN authentication with correct username/password."""
@@ -54,7 +54,7 @@ class SaslTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
             "({expects}), not {got}: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     @cases.OptionalityHelper.skipUnlessHasMechanism("PLAIN")
     def testPlainNoAuthzid(self):
         """“message   = [authzid] UTF8NUL authcid UTF8NUL passwd
@@ -119,7 +119,7 @@ class SaslTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
             "({expects}), not {got}: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     def testMechanismNotAvailable(self):
         """“If authentication fails, a 904 or 905 numeric will be sent”
         -- <http://ircv3.net/specs/extensions/sasl-3.1.html#the-authenticate-command>
@@ -141,7 +141,7 @@ class SaslTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
             fail_msg="Did not reply with 904 to “AUTHENTICATE FOO”: {msg}",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     @cases.OptionalityHelper.skipUnlessHasMechanism("PLAIN")
     def testPlainLarge(self):
         """Test the client splits large AUTHENTICATE messages whose payload
@@ -202,7 +202,7 @@ class SaslTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
     # I don't know how to do it, because it would make the registration
     # message's length too big for it to be valid.
 
-    @cases.SpecificationSelector.requiredBySpecification("IRCv3.1")
+    @cases.mark_specifications("IRCv3.1")
     @cases.OptionalityHelper.skipUnlessHasMechanism("PLAIN")
     def testPlainLargeEquals400(self):
         """Test the client splits large AUTHENTICATE messages whose payload

--- a/irctest/server_tests/test_statusmsg.py
+++ b/irctest/server_tests/test_statusmsg.py
@@ -3,13 +3,13 @@ from irctest.numerics import RPL_NAMREPLY
 
 
 class StatusmsgTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testInIsupport(self):
         """Check that the expected STATUSMSG parameter appears in our isupport list."""
         isupport = self.getISupport()
         self.assertEqual(isupport["STATUSMSG"], "~&@%+")
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testStatusmsg(self):
         """Test that STATUSMSG are sent to the intended recipients,
         with the intended prefixes."""

--- a/irctest/server_tests/test_user_commands.py
+++ b/irctest/server_tests/test_user_commands.py
@@ -14,7 +14,7 @@ from irctest.numerics import (
 
 
 class WhoisTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testWhoisUser(self):
         """Test basic WHOIS behavior"""
         nick = "myCoolNickname"
@@ -42,7 +42,7 @@ class WhoisTestCase(cases.BaseServerTestCase):
 
 
 class InvisibleTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testInvisibleWhois(self):
         """Test interaction between MODE +i and RPL_WHOISCHANNELS."""
         self.connectClient("userOne")
@@ -116,7 +116,7 @@ class InvisibleTestCase(cases.BaseServerTestCase):
             "RPL_WHOISCHANNELS should be sent for a non-invisible nick",
         )
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testWhoisAccount(self):
         """Test numeric 330, RPL_WHOISACCOUNT."""
         self.controller.registerUser(self, "shivaram", "sesame")
@@ -142,7 +142,7 @@ class InvisibleTestCase(cases.BaseServerTestCase):
 
 
 class AwayTestCase(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("RFC2812")
+    @cases.mark_specifications("RFC2812")
     def testAway(self):
         self.connectClient("bar")
         self.sendLine(1, "AWAY :I'm not here right now")
@@ -166,7 +166,7 @@ class AwayTestCase(cases.BaseServerTestCase):
 
 
 class TestNoCTCPMode(cases.BaseServerTestCase):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testNoCTCPMode(self):
         self.connectClient("bar", "bar")
         self.connectClient("qux", "qux")

--- a/irctest/server_tests/test_utf8.py
+++ b/irctest/server_tests/test_utf8.py
@@ -2,7 +2,7 @@ from irctest import cases
 
 
 class Utf8TestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testUtf8Validation(self):
         self.connectClient(
             "bar",

--- a/irctest/server_tests/test_znc_playback.py
+++ b/irctest/server_tests/test_znc_playback.py
@@ -22,7 +22,7 @@ class ZncPlaybackTestCase(cases.BaseServerTestCase):
     def config():
         return {"chathistory": True}
 
-    @cases.SpecificationSelector.requiredBySpecification("Oragono")
+    @cases.mark_specifications("Oragono")
     def testZncPlayback(self):
         early_time = int(time.time() - 60)
 

--- a/irctest/specifications.py
+++ b/irctest/specifications.py
@@ -5,10 +5,8 @@ import enum
 class Specifications(enum.Enum):
     RFC1459 = "RFC1459"
     RFC2812 = "RFC2812"
-    RFCDeprecated = "RFC-deprecated"
     IRC301 = "IRCv3.1"
     IRC302 = "IRCv3.2"
-    IRC302Deprecated = "IRCv3.2-deprecated"
     Oragono = "Oragono"
     Multiline = "multiline"
     MessageTags = "message-tags"

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,11 +2,10 @@
 markers =
     RFC1459
     RFC2812
-    RFC-deprecated
     IRCv3.1
     IRCv3.2
-    IRCv3.2-deprecated
     message-tags
     multiline
     Oragono
     strict
+    deprecated


### PR DESCRIPTION
Also rename `@cases.SpecificationSelector.requiredBySpecification("xxx")`
to `@cases.mark_specifications("xxx")` because it's shorter and looks
like pytest's own syntax