### PR TITLE
Use assertMessageMatch whenever possible, and generalize listMatch to accept regexps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Alternatively, run `pre-commit run -a`
 [Follow PEP 8](https://www.python.org/dev/peps/pep-0008/#naming-conventions),
 with these exceptions:
 
-* assertion methods (eg. `assertMessageEqual` are mixedCase to be consistent
+* assertion methods (eg. `assertMessageMatch` are mixedCase to be consistent
   with the unittest module)
 * other methods defined in `cases.py` are also mixedCase for consistency with
   the former, for now
@@ -67,7 +67,7 @@ This does not relax the requirement on documentating tests.
 
 **Use unittest-style assertions** (`self.assertEqual(x, y)` instead of
 pytest-style (`assert x == y`). This allows consistency with the assertion
-methods we define, such as `assertMessageEqual`.
+methods we define, such as `assertMessageMatch`.
 
 Always **add an error message in assertions**.
 `irctest` should show readable errors to people unfamiliar with the

--- a/irctest/cases.py
+++ b/irctest/cases.py
@@ -109,7 +109,7 @@ class _IrcTestCase(unittest.TestCase, Generic[TController]):
         Takes the message as first arguments, and comparisons to be made
         as keyword arguments.
 
-        Uses patma.list_match on the params argument.
+        Uses patma.match_list on the params argument.
         """
         error = self.messageDiffers(msg, **kwargs)
         if error:
@@ -145,7 +145,7 @@ class _IrcTestCase(unittest.TestCase, Generic[TController]):
                     msg=msg,
                 )
 
-        if params and not patma.list_match(msg.params, params):
+        if params and not patma.match_list(msg.params, params):
             fail_msg = fail_msg or "params to be {expects}, got {got}: {msg}"
             return fail_msg.format(
                 *extra_format, got=msg.params, expects=params, msg=msg

--- a/irctest/client_tests/test_tls.py
+++ b/irctest/client_tests/test_tls.py
@@ -3,6 +3,7 @@ import ssl
 
 from irctest import cases, runner, tls
 from irctest.exceptions import ConnectionClosed
+from irctest.patma import ANYSTR
 
 BAD_CERT = """
 -----BEGIN CERTIFICATE-----
@@ -162,9 +163,12 @@ class StsTestCase(cases.BaseClientTestCase, cases.OptionalityHelper):
         self.acceptClient(server=self.insecure_server)
 
         # Send STS policy to client
-        m = self.getMessage()
-        self.assertEqual(m.command, "CAP", "First message is not CAP LS.")
-        self.assertEqual(m.params[0], "LS", "First message is not CAP LS.")
+        self.assertMessageMatch(
+            self.getMessage(),
+            command="CAP",
+            params=["LS", ANYSTR],
+            fail_msg="First message is not CAP LS: {got}",
+        )
         self.sendLine("CAP * LS :sts=port={}".format(self.server.getsockname()[1]))
 
         # "If the client is not already connected securely to the server
@@ -204,9 +208,12 @@ class StsTestCase(cases.BaseClientTestCase, cases.OptionalityHelper):
         self.acceptClient(server=self.insecure_server)
 
         # Send STS policy to client
-        m = self.getMessage()
-        self.assertEqual(m.command, "CAP", "First message is not CAP LS.")
-        self.assertEqual(m.params[0], "LS", "First message is not CAP LS.")
+        self.assertMessageMatch(
+            self.getMessage(),
+            command="CAP",
+            params=["LS", ANYSTR],
+            fail_msg="First message is not CAP LS: {got}",
+        )
         self.sendLine("CAP * LS :sts=port={}".format(self.server.getsockname()[1]))
 
         # The client will reconnect to the TLS port. Unfortunately, it does

--- a/irctest/patma.py
+++ b/irctest/patma.py
@@ -1,0 +1,51 @@
+"""Pattern-matching utilities"""
+
+import dataclasses
+import re
+from typing import List, Union
+
+
+class Operator:
+    """Used as a wildcards and operators when matching message arguments
+    (see assertMessageMatch and match_list)"""
+
+    def __init__(self) -> None:
+        pass
+
+
+class AnyStr(Operator):
+    """Wildcard matching any string"""
+
+    def __repr__(self) -> str:
+        return "AnyStr"
+
+
+@dataclasses.dataclass
+class StrRe(Operator):
+    regexp: str
+
+    def __repr__(self) -> str:
+        return f"StrRe(r'{self.regexp}')"
+
+
+ANYSTR = AnyStr()
+"""Singleton, spares two characters"""
+
+
+def match_list(got: List[str], expected: List[Union[str, Operator]]) -> bool:
+    """Returns True iff the list are equal.
+    The ellipsis (aka. "..." aka triple dots) can be used on the 'expected'
+    side as a wildcard, matching any *single* value."""
+    if len(got) != len(expected):
+        return False
+    for (got_value, expected_value) in zip(got, expected):
+        if isinstance(expected_value, AnyStr):
+            # wildcard
+            continue
+        elif isinstance(expected_value, StrRe):
+            if not re.match(expected_value.regexp, got_value):
+                return False
+        else:
+            if got_value != expected_value:
+                return False
+    return True

--- a/irctest/server_tests/test_cap.py
+++ b/irctest/server_tests/test_cap.py
@@ -1,5 +1,5 @@
 from irctest import cases
-from irctest.cases import AnyStr
+from irctest.patma import ANYSTR
 from irctest.runner import CapabilityNotSupported, ImplementationChoice
 
 
@@ -40,7 +40,7 @@ class CapTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.assertMessageMatch(
             m,
             command="CAP",
-            params=[AnyStr, "NAK", "foo"],
+            params=[ANYSTR, "NAK", "foo"],
             fail_msg="Expected CAP NAK after requesting non-existing "
             "capability, got {msg}.",
         )
@@ -67,7 +67,7 @@ class CapTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.assertMessageMatch(
             m,
             command="CAP",
-            params=[AnyStr, "NAK", "foo qux bar baz qux quux"],
+            params=[ANYSTR, "NAK", "foo qux bar baz qux quux"],
             fail_msg="Expected “CAP NAK :foo qux bar baz qux quux” after "
             "sending “CAP REQ :foo qux bar baz qux quux”, but got {msg}.",
         )
@@ -86,7 +86,7 @@ class CapTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.assertMessageMatch(
             m,
             command="CAP",
-            params=[AnyStr, "NAK", "foo multi-prefix bar"],
+            params=[ANYSTR, "NAK", "foo multi-prefix bar"],
             fail_msg="Expected “CAP NAK :foo multi-prefix bar” after "
             "sending “CAP REQ :foo multi-prefix bar”, but got {msg}.",
         )
@@ -95,7 +95,7 @@ class CapTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.assertMessageMatch(
             m,
             command="CAP",
-            params=[AnyStr, "NAK", "multi-prefix bar"],
+            params=[ANYSTR, "NAK", "multi-prefix bar"],
             fail_msg="Expected “CAP NAK :multi-prefix bar” after "
             "sending “CAP REQ :multi-prefix bar”, but got {msg}.",
         )
@@ -104,7 +104,7 @@ class CapTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.assertMessageMatch(
             m,
             command="CAP",
-            params=[AnyStr, "NAK", "foo multi-prefix"],
+            params=[ANYSTR, "NAK", "foo multi-prefix"],
             fail_msg="Expected “CAP NAK :foo multi-prefix” after "
             "sending “CAP REQ :foo multi-prefix”, but got {msg}.",
         )
@@ -114,7 +114,7 @@ class CapTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.assertMessageMatch(
             m,
             command="CAP",
-            params=[AnyStr, "ACK", "multi-prefix"],
+            params=[ANYSTR, "ACK", "multi-prefix"],
             fail_msg="Expected “CAP ACK :multi-prefix” after "
             "sending “CAP REQ :multi-prefix”, but got {msg}.",
         )
@@ -134,7 +134,7 @@ class CapTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.sendLine(1, "user user 0 * realname")
         self.sendLine(1, "CAP END")
         m = self.getRegistrationMessage(1)
-        self.assertMessageMatch(m, command="CAP", params=[AnyStr, "ACK", AnyStr])
+        self.assertMessageMatch(m, command="CAP", params=[ANYSTR, "ACK", ANYSTR])
         self.assertEqual(
             set(m.params[2].split()), {cap1, cap2}, "Didn't ACK both REQed caps"
         )
@@ -152,9 +152,9 @@ class CapTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.sendLine(1, f"CAP REQ :-{cap2}")
         m = self.getMessage(1)
         # Must be either ACK or NAK
-        if self.messageDiffers(m, command="CAP", params=[AnyStr, "ACK", f"-{cap2}"]):
+        if self.messageDiffers(m, command="CAP", params=[ANYSTR, "ACK", f"-{cap2}"]):
             self.assertMessageMatch(
-                m, command="CAP", params=[AnyStr, "NAK", f"-{cap2}"]
+                m, command="CAP", params=[ANYSTR, "NAK", f"-{cap2}"]
             )
             raise ImplementationChoice(f"Does not support CAP REQ -{cap2}")
 

--- a/irctest/server_tests/test_labeled_responses.py
+++ b/irctest/server_tests/test_labeled_responses.py
@@ -8,6 +8,7 @@ so there may be many false positives.
 import re
 
 from irctest import cases
+from irctest.patma import StrRe
 
 
 class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
@@ -674,11 +675,10 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
 
         # valid BATCH start line:
         batch_start = m[0]
-        self.assertMessageMatch(batch_start, command="BATCH")
-        self.assertEqual(len(batch_start.params), 2)
-        self.assertTrue(
-            batch_start.params[0].startswith("+"),
-            "batch start param must begin with +, got %s" % (batch_start.params[0],),
+        self.assertMessageMatch(
+            batch_start,
+            command="BATCH",
+            params=[StrRe(r"\+.*"), "labeled-response"],
         )
         batch_id = batch_start.params[0][1:]
         # batch id MUST be alphanumerics and hyphens
@@ -686,7 +686,6 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
             re.match(r"^[A-Za-z0-9\-]+$", batch_id) is not None,
             "batch id must be alphanumerics and hyphens, got %r" % (batch_id,),
         )
-        self.assertEqual(batch_start.params[1], "labeled-response")
         self.assertEqual(batch_start.tags.get("label"), "12345")
 
         # valid BATCH end line
@@ -712,6 +711,7 @@ class LabeledResponsesTestCase(cases.BaseServerTestCase, cases.OptionalityHelper
         m = ms[0]
         self.assertEqual(m.command, "PONG")
         self.assertEqual(m.params[-1], "adhoctestline")
+
         # check the label
         self.assertEqual(m.tags.get("label"), "98765")
 

--- a/irctest/server_tests/test_monitor.py
+++ b/irctest/server_tests/test_monitor.py
@@ -11,6 +11,7 @@ from irctest.numerics import (
     RPL_MONOFFLINE,
     RPL_MONONLINE,
 )
+from irctest.patma import ANYSTR, StrRe
 
 
 class MonitorTestCase(cases.BaseServerTestCase):
@@ -24,21 +25,9 @@ class MonitorTestCase(cases.BaseServerTestCase):
         self.assertMessageMatch(
             m,
             command="730",  # RPL_MONONLINE
-            fail_msg="Sent non-730 (RPL_MONONLINE) message after "
-            "monitored nick “{}” connected: {msg}",
-            extra_format=(nick,),
-        )
-        self.assertEqual(
-            len(m.params),
-            2,
-            m,
-            fail_msg="Invalid number of params of RPL_MONONLINE: {msg}",
-        )
-        self.assertEqual(
-            m.params[1].split("!")[0],
-            "bar",
-            fail_msg="730 (RPL_MONONLINE) with bad target after “{}” "
-            "connects: {msg}",
+            params=[ANYSTR, StrRe(nick + "(!.*)?")],
+            fail_msg="Unexpected notification that monitored nick “{}” "
+            "is online: {msg}",
             extra_format=(nick,),
         )
 
@@ -48,21 +37,9 @@ class MonitorTestCase(cases.BaseServerTestCase):
         self.assertMessageMatch(
             m,
             command="731",  # RPL_MONOFFLINE
-            fail_msg="Did not reply with 731 (RPL_MONOFFLINE) to "
-            "“MONITOR + {}”, while “{}” is offline: {msg}",
-            extra_format=(nick, nick),
-        )
-        self.assertEqual(
-            len(m.params),
-            2,
-            m,
-            fail_msg="Invalid number of params of RPL_MONOFFLINE: {msg}",
-        )
-        self.assertEqual(
-            m.params[1].split("!")[0],
-            "bar",
-            fail_msg="731 (RPL_MONOFFLINE) reply to “MONITOR + {}” "
-            "with bad target: {msg}",
+            params=[ANYSTR, nick],
+            fail_msg="Unexpected notification that monitored nick “{}” "
+            "is offline: {msg}",
             extra_format=(nick,),
         )
 
@@ -163,32 +140,9 @@ class MonitorTestCase(cases.BaseServerTestCase):
         )
         if m1.command == "731":
             (m1, m2) = (m2, m1)
-        self.assertEqual(
-            len(m1.params),
-            2,
-            m1,
-            fail_msg="Invalid number of params of RPL_MONONLINE: {msg}",
-        )
-        self.assertEqual(
-            len(m2.params),
-            2,
-            m2,
-            fail_msg="Invalid number of params of RPL_MONONLINE: {msg}",
-        )
-        self.assertEqual(
-            m1.params[1].split("!")[0],
-            "bar",
-            m1,
-            fail_msg="730 (RPL_MONONLINE) with bad target after "
-            "“MONITOR + bar,baz” and “bar” is connected: {msg}",
-        )
-        self.assertEqual(
-            m2.params[1].split("!")[0],
-            "baz",
-            m2,
-            fail_msg="731 (RPL_MONOFFLINE) with bad target after "
-            "“MONITOR + bar,baz” and “baz” is disconnected: {msg}",
-        )
+
+        self.assertMononline(None, "bar", m=m1)
+        self.assertMonoffline(None, "baz", m=m2)
 
     @cases.mark_specifications("IRCv3")
     @cases.mark_isupport("MONITOR")

--- a/irctest/server_tests/test_multi_prefix.py
+++ b/irctest/server_tests/test_multi_prefix.py
@@ -4,6 +4,7 @@ Tests multi-prefix.
 """
 
 from irctest import cases
+from irctest.patma import ANYSTR
 
 
 class MultiPrefixTestCase(cases.BaseServerTestCase):
@@ -32,7 +33,7 @@ class MultiPrefixTestCase(cases.BaseServerTestCase):
         self.assertMessageMatch(
             reply,
             command="353",
-            params=["foo", reply.params[1], "#chan", "@+foo"],
+            params=["foo", ANYSTR, "#chan", "@+foo"],
             fail_msg="Expected NAMES response (353) with @+foo, got: {msg}",
         )
         self.getMessages(1)

--- a/irctest/server_tests/test_register_verify.py
+++ b/irctest/server_tests/test_register_verify.py
@@ -1,4 +1,5 @@
 from irctest import cases
+from irctest.patma import ANYSTR
 
 REGISTER_CAP_NAME = "draft/register"
 
@@ -23,7 +24,7 @@ class TestRegisterBeforeConnect(cases.BaseServerTestCase):
         self.sendLine("bar", "REGISTER * shivarampassphrase")
         msgs = self.getMessages("bar")
         register_response = [msg for msg in msgs if msg.command == "REGISTER"][0]
-        self.assertEqual(register_response.params[0], "SUCCESS")
+        self.assertMessageMatch(register_response, params=["SUCCESS", ANYSTR, ANYSTR])
 
 
 class TestRegisterBeforeConnectDisallowed(cases.BaseServerTestCase):
@@ -46,7 +47,9 @@ class TestRegisterBeforeConnectDisallowed(cases.BaseServerTestCase):
         self.sendLine("bar", "REGISTER * shivarampassphrase")
         msgs = self.getMessages("bar")
         fail_response = [msg for msg in msgs if msg.command == "FAIL"][0]
-        self.assertEqual(fail_response.params[:2], ["REGISTER", "DISALLOWED"])
+        self.assertMessageMatch(
+            fail_response, params=["REGISTER", "DISALLOWED", ANYSTR]
+        )
 
 
 class TestRegisterEmailVerified(cases.BaseServerTestCase):
@@ -80,7 +83,9 @@ class TestRegisterEmailVerified(cases.BaseServerTestCase):
         self.sendLine("bar", "REGISTER * shivarampassphrase")
         msgs = self.getMessages("bar")
         fail_response = [msg for msg in msgs if msg.command == "FAIL"][0]
-        self.assertEqual(fail_response.params[:2], ["REGISTER", "INVALID_EMAIL"])
+        self.assertMessageMatch(
+            fail_response, params=["REGISTER", "INVALID_EMAIL", ANYSTR, ANYSTR]
+        )
 
     @cases.mark_specifications("Oragono")
     def testAfterConnect(self):
@@ -88,7 +93,9 @@ class TestRegisterEmailVerified(cases.BaseServerTestCase):
         self.sendLine("bar", "REGISTER * shivarampassphrase")
         msgs = self.getMessages("bar")
         fail_response = [msg for msg in msgs if msg.command == "FAIL"][0]
-        self.assertEqual(fail_response.params[:2], ["REGISTER", "INVALID_EMAIL"])
+        self.assertMessageMatch(
+            fail_response, params=["REGISTER", "INVALID_EMAIL", ANYSTR, ANYSTR]
+        )
 
 
 class TestRegisterNoLandGrabs(cases.BaseServerTestCase):
@@ -111,4 +118,6 @@ class TestRegisterNoLandGrabs(cases.BaseServerTestCase):
         self.sendLine("bar", "REGISTER * shivarampassphrase")
         msgs = self.getMessages("bar")
         fail_response = [msg for msg in msgs if msg.command == "FAIL"][0]
-        self.assertEqual(fail_response.params[:2], ["REGISTER", "USERNAME_EXISTS"])
+        self.assertMessageMatch(
+            fail_response, params=["REGISTER", "USERNAME_EXISTS", ANYSTR, ANYSTR]
+        )

--- a/irctest/server_tests/test_relaymsg.py
+++ b/irctest/server_tests/test_relaymsg.py
@@ -1,5 +1,6 @@
 from irctest import cases
 from irctest.irc_utils.junkdrawer import random_name
+from irctest.patma import ANYSTR
 from irctest.server_tests.test_chathistory import CHATHISTORY_CAP, EVENT_PLAYBACK_CAP
 
 RELAYMSG_CAP = "draft/relaymsg"
@@ -46,14 +47,18 @@ class RelaymsgTestCase(cases.BaseServerTestCase):
         self.getMessages("qux")
 
         self.sendLine("baz", "RELAYMSG %s invalid!nick/discord hi" % (chname,))
-        response = self.getMessages("baz")[0]
-        self.assertEqual(response.command, "FAIL")
-        self.assertEqual(response.params[:2], ["RELAYMSG", "INVALID_NICK"])
+        self.assertMessageMatch(
+            self.getMessages("baz")[0],
+            command="FAIL",
+            params=["RELAYMSG", "INVALID_NICK", ANYSTR],
+        )
 
         self.sendLine("baz", "RELAYMSG %s regular_nick hi" % (chname,))
-        response = self.getMessages("baz")[0]
-        self.assertEqual(response.command, "FAIL")
-        self.assertEqual(response.params[:2], ["RELAYMSG", "INVALID_NICK"])
+        self.assertMessageMatch(
+            self.getMessages("baz")[0],
+            command="FAIL",
+            params=["RELAYMSG", "INVALID_NICK", ANYSTR],
+        )
 
         self.sendLine("baz", "RELAYMSG %s smt/discord hi" % (chname,))
         response = self.getMessages("baz")[0]
@@ -81,9 +86,11 @@ class RelaymsgTestCase(cases.BaseServerTestCase):
         )
 
         self.sendLine("qux", "RELAYMSG %s smt/discord :hi a third time" % (chname,))
-        response = self.getMessages("qux")[0]
-        self.assertEqual(response.command, "FAIL")
-        self.assertEqual(response.params[:2], ["RELAYMSG", "PRIVS_NEEDED"])
+        self.assertMessageMatch(
+            self.getMessages("qux")[0],
+            command="FAIL",
+            params=["RELAYMSG", "PRIVS_NEEDED", ANYSTR],
+        )
 
         # grant qux chanop, allowing relaymsg
         self.sendLine("baz", "MODE %s +o qux" % (chname,))

--- a/irctest/server_tests/test_roleplay.py
+++ b/irctest/server_tests/test_roleplay.py
@@ -1,6 +1,7 @@
 from irctest import cases
 from irctest.irc_utils.junkdrawer import random_name
 from irctest.numerics import ERR_CANNOTSENDRP
+from irctest.patma import StrRe
 
 
 class RoleplayTestCase(cases.BaseServerTestCase):
@@ -40,29 +41,29 @@ class RoleplayTestCase(cases.BaseServerTestCase):
 
         self.sendLine(bar, "NPC %s bilbo too much bread" % (chan,))
         reply = self.getMessages(bar)[0]
-        self.assertEqual(reply.command, "PRIVMSG")
-        self.assertEqual(reply.params[0], chan)
+        self.assertMessageMatch(
+            reply, command="PRIVMSG", params=[chan, StrRe(".*too much bread.*")]
+        )
         self.assertTrue(reply.prefix.startswith("*bilbo*!"))
-        self.assertIn("too much bread", reply.params[1])
 
         reply = self.getMessages(qux)[0]
-        self.assertEqual(reply.command, "PRIVMSG")
-        self.assertEqual(reply.params[0], chan)
+        self.assertMessageMatch(
+            reply, command="PRIVMSG", params=[chan, StrRe(".*too much bread.*")]
+        )
         self.assertTrue(reply.prefix.startswith("*bilbo*!"))
-        self.assertIn("too much bread", reply.params[1])
 
         self.sendLine(bar, "SCENE %s dark and stormy night" % (chan,))
         reply = self.getMessages(bar)[0]
-        self.assertEqual(reply.command, "PRIVMSG")
-        self.assertEqual(reply.params[0], chan)
+        self.assertMessageMatch(
+            reply, command="PRIVMSG", params=[chan, StrRe(".*dark and stormy night.*")]
+        )
         self.assertTrue(reply.prefix.startswith("=Scene=!"))
-        self.assertIn("dark and stormy night", reply.params[1])
 
         reply = self.getMessages(qux)[0]
-        self.assertEqual(reply.command, "PRIVMSG")
-        self.assertEqual(reply.params[0], chan)
+        self.assertMessageMatch(
+            reply, command="PRIVMSG", params=[chan, StrRe(".*dark and stormy night.*")]
+        )
         self.assertTrue(reply.prefix.startswith("=Scene=!"))
-        self.assertIn("dark and stormy night", reply.params[1])
 
         # test history storage
         self.sendLine(qux, "CHATHISTORY LATEST %s * 10" % (chan,))
@@ -71,7 +72,7 @@ class RoleplayTestCase(cases.BaseServerTestCase):
             for msg in self.getMessages(qux)
             if msg.command == "PRIVMSG" and "bilbo" in msg.prefix
         ][0]
-        self.assertEqual(reply.command, "PRIVMSG")
-        self.assertEqual(reply.params[0], chan)
+        self.assertMessageMatch(
+            reply, command="PRIVMSG", params=[chan, StrRe(".*too much bread.*")]
+        )
         self.assertTrue(reply.prefix.startswith("*bilbo*!"))
-        self.assertIn("too much bread", reply.params[1])

--- a/irctest/server_tests/test_sasl.py
+++ b/irctest/server_tests/test_sasl.py
@@ -1,6 +1,7 @@
 import base64
 
 from irctest import cases
+from irctest.patma import ANYSTR
 
 
 class RegistrationTestCase(cases.BaseServerTestCase):
@@ -44,14 +45,8 @@ class SaslTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.assertMessageMatch(
             m,
             command="900",
-            fail_msg="Did not send 900 after correct SASL authentication.",
-        )
-        self.assertEqual(
-            m.params[2],
-            "jilles",
-            m,
-            fail_msg="900 should contain the account name as 3rd argument "
-            "({expects}), not {got}: {msg}",
+            params=[ANYSTR, ANYSTR, "jilles", ANYSTR],
+            fail_msg="Unexpected reply to correct SASL authentication: {msg}",
         )
 
     @cases.mark_specifications("IRCv3")
@@ -109,14 +104,8 @@ class SaslTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.assertMessageMatch(
             m,
             command="900",
-            fail_msg="Did not send 900 after correct SASL authentication.",
-        )
-        self.assertEqual(
-            m.params[2],
-            "jilles",
-            m,
-            fail_msg="900 should contain the account name as 3rd argument "
-            "({expects}), not {got}: {msg}",
+            params=[ANYSTR, ANYSTR, "jilles", ANYSTR],
+            fail_msg="Unexpected reply to correct SASL authentication: {msg}",
         )
 
     @cases.mark_specifications("IRCv3")

--- a/irctest/server_tests/test_user_commands.py
+++ b/irctest/server_tests/test_user_commands.py
@@ -151,10 +151,11 @@ class AwayTestCase(cases.BaseServerTestCase):
 
         self.connectClient("qux")
         self.sendLine(2, "PRIVMSG bar :what's up")
-        replies = self.getMessages(2)
-        self.assertEqual(len(replies), 1)
-        self.assertEqual(replies[0].command, RPL_AWAY)
-        self.assertEqual(replies[0].params, ["qux", "bar", "I'm not here right now"])
+        self.assertMessageMatch(
+            self.getMessage(2),
+            command=RPL_AWAY,
+            params=["qux", "bar", "I'm not here right now"],
+        )
 
         self.sendLine(1, "AWAY")
         replies = self.getMessages(1)
@@ -174,7 +175,9 @@ class TestNoCTCPMode(cases.BaseServerTestCase):
         self.sendLine("qux", "PRIVMSG bar :\x01VERSION\x01")
         self.getMessages("qux")
         relay = [msg for msg in self.getMessages("bar") if msg.command == "PRIVMSG"][0]
-        self.assertEqual(relay.params[-1], "\x01VERSION\x01")
+        self.assertMessageMatch(
+            relay, command="PRIVMSG", params=["bar", "\x01VERSION\x01"]
+        )
 
         # set the no-CTCP user mode on bar:
         self.sendLine("bar", "MODE bar +T")


### PR DESCRIPTION
it's stricter this way + hopefully more readable and better error msgs

Note: it makes oragono tests fail because it doesn't follow the latest version of the register spec