### PR TITLE
allow ERR_INPUTTOOLONG if a PRIVMSG cannot be relayed

### DIFF
--- a/irctest/server_tests/test_message_tags.py
+++ b/irctest/server_tests/test_message_tags.py
@@ -154,25 +154,30 @@ class MessageTagsTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.assertEqual(len(max_privmsg), 4096 + (512 - 2))
         self.sendLine("alice", max_privmsg)
         echo = self.getMessage("alice")
-        relay = self.getMessage("bob")
-        self.assertMessageMatch(
-            echo,
-            command="PRIVMSG",
-            params=["#test", StrRe("b{400,496}")],
-            tags={"+baz": "a" * 4081, "msgid": StrRe(".+"), **ANYDICT},
-        )
-        self.assertMessageMatch(
-            relay,
-            command="PRIVMSG",
-            params=["#test", StrRe("b{400,496}")],
-            tags={"+baz": "a" * 4081, "msgid": StrRe(".+"), **ANYDICT},
-        )
-        self.assertEqual(echo.tags["msgid"], relay.tags["msgid"])
-        # message may have been truncated
-        self.assertIn("b" * 400, echo.params[1])
-        self.assertEqual(echo.params[1].rstrip("b"), "")
-        self.assertIn("b" * 400, relay.params[1])
-        self.assertEqual(relay.params[1].rstrip("b"), "")
+        # the server may still reject this message on the grounds that the final
+        # parameter is too long to be relayed without truncation, once alice's
+        # NUH is included. however, if the message was accepted, the tags MUST
+        # be relayed intact, because they are unquestionably valid:
+        if echo.command != ERR_INPUTTOOLONG:
+            relay = self.getMessage("bob")
+            self.assertMessageMatch(
+                echo,
+                command="PRIVMSG",
+                params=["#test", StrRe("b{400,496}")],
+                tags={"+baz": "a" * 4081, "msgid": StrRe(".+"), **ANYDICT},
+            )
+            self.assertMessageMatch(
+                relay,
+                command="PRIVMSG",
+                params=["#test", StrRe("b{400,496}")],
+                tags={"+baz": "a" * 4081, "msgid": StrRe(".+"), **ANYDICT},
+            )
+            self.assertEqual(echo.tags["msgid"], relay.tags["msgid"])
+            # message may have been truncated
+            self.assertIn("b" * 400, echo.params[1])
+            self.assertEqual(echo.params[1].rstrip("b"), "")
+            self.assertIn("b" * 400, relay.params[1])
+            self.assertEqual(relay.params[1].rstrip("b"), "")
 
         excess_privmsg = "@foo=bar;+baz=%s PRIVMSG #test %s" % ("a" * 4082, "b" * 495)
         # TAGMSG data is over the limit, but we're within the overall limit for a line

--- a/irctest/server_tests/test_message_tags.py
+++ b/irctest/server_tests/test_message_tags.py
@@ -108,6 +108,7 @@ class MessageTagsTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         self.assertEqual(alice_msg.tags["msgid"], bob_msg.tags["msgid"])
 
     @cases.mark_capabilities("message-tags")
+    @cases.mark_specifications("ircdocs")
     def testLengthLimits(self):
         self.connectClient(
             "alice",
@@ -157,7 +158,9 @@ class MessageTagsTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         # the server may still reject this message on the grounds that the final
         # parameter is too long to be relayed without truncation, once alice's
         # NUH is included. however, if the message was accepted, the tags MUST
-        # be relayed intact, because they are unquestionably valid:
+        # be relayed intact, because they are unquestionably valid. See the
+        # original context of ERR_INPUTTOOLONG:
+        # https://defs.ircdocs.horse/defs/numerics.html#err-inputtoolong-417
         if echo.command != ERR_INPUTTOOLONG:
             relay = self.getMessage("bob")
             self.assertMessageMatch(


### PR DESCRIPTION
This is prep for #1577; the corresponding Oragono change isn't ready yet, but this test change is compatible with both behaviors.