### PR TITLE
test for Oragono disallowing truncation

### DIFF
--- a/.github/workflows/oragono.yml
+++ b/.github/workflows/oragono.yml
@@ -18,6 +18,11 @@ jobs:
       with:
         python-version: 3.7
 
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '~1.16'
+    - run: go version
+
     - name: Cache dependencies
       uses: actions/cache@v2
       with:

--- a/irctest/controllers/oragono.py
+++ b/irctest/controllers/oragono.py
@@ -39,6 +39,9 @@ BASE_CONFIG = {
         },
         "enforce-utf8": True,
         "relaymsg": {"enabled": True, "separators": "/", "available-to-chanops": True},
+        "compatibility": {
+            "allow-truncation": False,
+        },
     },
     "accounts": {
         "authentication-enabled": True,


### PR DESCRIPTION
Not sure if these will meet the new style/quality requirements, I can fix them.

These are integration tests covering oragono/oragono#1577 (they enable the new mode of operation where PRIVMSG are rejected instead of truncated).