### PR TITLE
Add test for message matching commands

### DIFF
--- a/irctest/cases.py
+++ b/irctest/cases.py
@@ -99,7 +99,8 @@ class _IrcTestCase(unittest.TestCase, Generic[TController]):
 
     def setUp(self) -> None:
         super().setUp()
-        self.controller = self.controllerClass(self.config())
+        if self.controllerClass is not None:
+            self.controller = self.controllerClass(self.config())
         if self.show_io:
             print("---- new test ----")
 
@@ -162,9 +163,10 @@ class _IrcTestCase(unittest.TestCase, Generic[TController]):
 
         if nick:
             got_nick = msg.prefix.split("!")[0] if msg.prefix else None
-            if msg.prefix is None:
+            if nick != got_nick:
                 fail_msg = (
-                    fail_msg or "expected nick to be {expects}, got {got} prefix: {msg}"
+                    fail_msg
+                    or "expected nick to be {expects}, got {got} instead: {msg}"
                 )
                 return fail_msg.format(
                     *extra_format, got=got_nick, expects=nick, param=key, msg=msg
@@ -354,9 +356,7 @@ class BaseClientTestCase(_IrcTestCase[basecontrollers.BaseClientController]):
         return line
 
     def getMessage(
-        self,
-        *args: Any,
-        filter_pred: Optional[Callable[[Message], bool]] = None,
+        self, *args: Any, filter_pred: Optional[Callable[[Message], bool]] = None
     ) -> Message:
         """Gets a message and returns it. If a filter predicate is given,
         fetches messages until the predicate returns a False on a message,

--- a/irctest/self_tests/test_cases.py
+++ b/irctest/self_tests/test_cases.py
@@ -1,0 +1,153 @@
+from typing import Dict, List, Tuple
+
+import pytest
+
+from irctest import cases
+from irctest.irc_utils.message_parser import parse_message
+from irctest.patma import ANYDICT, ANYSTR, StrRe
+
+# fmt: off
+MESSAGE_SPECS: List[Tuple[Dict, List[str], List[str]]] = [
+    (
+        # the specification:
+        dict(
+            command="PRIVMSG",
+            params=["#chan", "hello"],
+        ),
+        # matches:
+        [
+            "PRIVMSG #chan hello",
+            "PRIVMSG #chan :hello",
+            "@tag1=bar PRIVMSG #chan :hello",
+            "@tag1=bar;tag2= PRIVMSG #chan :hello",
+            ":foo!baz@qux PRIVMSG #chan hello",
+            "@tag1=bar :foo!baz@qux PRIVMSG #chan :hello",
+        ],
+        # and does not match:
+        [
+            "PRIVMSG #chan hello2",
+            "PRIVMSG #chan2 hello",
+        ]
+    ),
+    (
+        # the specification:
+        dict(
+            command="PRIVMSG",
+            params=["#chan", StrRe("hello.*")],
+        ),
+        # matches:
+        [
+            "PRIVMSG #chan hello",
+            "PRIVMSG #chan :hello",
+            "PRIVMSG #chan hello2",
+            "@tag1=bar PRIVMSG #chan :hello",
+            "@tag1=bar;tag2= PRIVMSG #chan :hello",
+            ":foo!baz@qux PRIVMSG #chan hello",
+            "@tag1=bar :foo!baz@qux PRIVMSG #chan :hello",
+        ],
+        # and does not match:
+        [
+            "PRIVMSG #chan :hi",
+            "PRIVMSG #chan2 hello",
+        ]
+    ),
+    (
+        # the specification:
+        dict(
+            nick="foo",
+            command="PRIVMSG",
+        ),
+        # matches:
+        [
+            ":foo!baz@qux PRIVMSG #chan hello",
+            "@tag1=bar :foo!baz@qux PRIVMSG #chan :hello",
+        ],
+        # and does not match:
+        [
+            "PRIVMSG #chan :hi",
+            ":foo2!baz@qux PRIVMSG #chan hello",
+            "@tag1=bar :foo2!baz@qux PRIVMSG #chan :hello",
+        ]
+    ),
+    (
+        # the specification:
+        dict(
+            tags={"tag1": "bar"},
+            command="PRIVMSG",
+            params=["#chan", "hello"],
+        ),
+        # matches:
+        [
+            "@tag1=bar PRIVMSG #chan :hello",
+            "@tag1=bar :foo!baz@qux PRIVMSG #chan :hello",
+        ],
+        # and does not match:
+        [
+            "@tag1=bar;tag2= PRIVMSG #chan :hello",
+            "@tag1=value1 PRIVMSG #chan :hello",
+            "PRIVMSG #chan hello",
+            ":foo!baz@qux PRIVMSG #chan hello",
+        ]
+    ),
+    (
+        # the specification:
+        dict(
+            tags={"tag1": ANYSTR},
+            command="PRIVMSG",
+            params=["#chan", ANYSTR],
+        ),
+        # matches:
+        [
+            "@tag1=bar PRIVMSG #chan :hello",
+            "@tag1=value1 PRIVMSG #chan :hello",
+            "@tag1=bar :foo!baz@qux PRIVMSG #chan :hello",
+        ],
+        # and does not match:
+        [
+            "@tag1=bar;tag2= PRIVMSG #chan :hello",
+            "PRIVMSG #chan hello",
+            ":foo!baz@qux PRIVMSG #chan hello",
+        ]
+    ),
+    (
+        # the specification:
+        dict(
+            tags={"tag1": "bar", **ANYDICT},
+            command="PRIVMSG",
+            params=["#chan", "hello"],
+        ),
+        # matches:
+        [
+            "@tag1=bar PRIVMSG #chan :hello",
+            "@tag1=bar;tag2= PRIVMSG #chan :hello",
+            "@tag1=bar :foo!baz@qux PRIVMSG #chan :hello",
+        ],
+        # and does not match:
+        [
+            "PRIVMG #chan :hello",
+            "@tag1=value1 PRIVMSG #chan :hello",
+            "PRIVMSG #chan hello2",
+            "PRIVMSG #chan2 hello",
+            ":foo!baz@qux PRIVMSG #chan hello",
+        ]
+    ),
+]
+# fmt: on
+
+
+class IrcTestCaseTestCase(cases._IrcTestCase):
+    def test_message_matching(self):
+        for (spec, positive_matches, negative_matches) in MESSAGE_SPECS:
+            with self.subTest(spec):
+                for msg in positive_matches:
+                    with self.subTest(msg):
+                        assert not self.messageDiffers(parse_message(msg), **spec), msg
+                        assert self.messageEqual(parse_message(msg), **spec), msg
+                        self.assertMessageMatch(parse_message(msg), **spec), msg
+
+                for msg in negative_matches:
+                    with self.subTest(msg):
+                        assert self.messageDiffers(parse_message(msg), **spec), msg
+                        assert not self.messageEqual(parse_message(msg), **spec), msg
+                        with pytest.raises(AssertionError):
+                            self.assertMessageMatch(parse_message(msg), **spec), msg


### PR DESCRIPTION
+ fix a bug in tested code
+ change conftest.py to allow missing --controller arg (which is
  an UI improvement, as it allows using 'pytest --help' now)