### PR TITLE
rename Oragono to Ergo

### DIFF
--- a/.github/workflows/charybdis.yml
+++ b/.github/workflows/charybdis.yml
@@ -49,5 +49,5 @@ jobs:
     - name: Test with pytest
       run: |
         # testQuitErrors is very flaky
-        PATH=~/.local/bin:$PATH pytest --controller=irctest.controllers.charybdis -k 'not Oragono and not deprecated and not strict and not testDoubleKickMessages and not testQuitErrors'
+        PATH=~/.local/bin:$PATH pytest --controller=irctest.controllers.charybdis -k 'not Ergo and not deprecated and not strict and not testDoubleKickMessages and not testQuitErrors'
 

--- a/.github/workflows/inspircd.yml
+++ b/.github/workflows/inspircd.yml
@@ -51,5 +51,5 @@ jobs:
         # testNoticeNonexistentChannel fails because of https://github.com/inspircd/inspircd/issues/1849
         # testDirectMessageEcho fails because of https://github.com/inspircd/inspircd/issues/1851
         # testKeyValidation fails because of https://github.com/inspircd/inspircd/issues/1850
-        PATH=~/.local/bin:$PATH pytest --controller irctest.controllers.inspircd -k 'not Oragono and not deprecated and not strict and not testNoticeNonexistentChannel and not testDirectMessageEcho and not testKeyValidation'
+        PATH=~/.local/bin:$PATH pytest --controller irctest.controllers.inspircd -k 'not Ergo and not deprecated and not strict and not testNoticeNonexistentChannel and not testDirectMessageEcho and not testKeyValidation'
 

--- a/.github/workflows/ircd-seven.yml
+++ b/.github/workflows/ircd-seven.yml
@@ -54,6 +54,6 @@ jobs:
         # testPartMessage and testBasicPartRfc2812 fail because ircd-seven adds quotes around the message
         # testListOne fails because ircd-seven makes channels secret by default
         # testQuitErrors is very flaky
-        PATH=~/.local/bin:$PATH pytest --controller=irctest.controllers.ircd_seven -k 'not Oragono and not deprecated and not strict and not testDoubleKickMessages and not testNakWhole and not testPartMessage and not testBasicPartRfc2812 and not testListOne and not testQuitErrors'
+        PATH=~/.local/bin:$PATH pytest --controller=irctest.controllers.ircd_seven -k 'not Ergo and not deprecated and not strict and not testDoubleKickMessages and not testNakWhole and not testPartMessage and not testBasicPartRfc2812 and not testListOne and not testQuitErrors'
 
 

--- a/.github/workflows/oragono.yml
+++ b/.github/workflows/oragono.yml
@@ -1,4 +1,4 @@
-name: irctest with Oragono
+name: irctest with Ergo
 
 on:
   push:
@@ -28,27 +28,27 @@ jobs:
       with:
         path: |
           ~/.cache
-          $GITHUB_WORKSPACE/oragono
-        key: ${{ runner.os }}-oragono
+          $GITHUB_WORKSPACE/ergo
+        key: ${{ runner.os }}-ergo
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install pytest -r requirements.txt
 
-    - name: Checkout Oragono
+    - name: Checkout Ergo
       uses: actions/checkout@v2
       with:
-        repository: oragono/oragono
+        repository: ergo/ergo
         ref: irctest_stable
-        path: oragono
+        path: ergo
 
-    - name: Build Oragono
+    - name: Build Ergo
       run: |
-        cd $GITHUB_WORKSPACE/oragono/
+        cd $GITHUB_WORKSPACE/ergo/
         make build
         make install
 
     - name: Test with pytest
       run: |
-        PATH=~/go/bin:$PATH pytest --controller=irctest.controllers.oragono -k 'not deprecated'
+        PATH=~/go/bin:$PATH pytest --controller=irctest.controllers.ergo -k 'not deprecated'

--- a/.github/workflows/oragono.yml
+++ b/.github/workflows/oragono.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Checkout Ergo
       uses: actions/checkout@v2
       with:
-        repository: ergo/ergo
+        repository: ergochat/ergo
         ref: irctest_stable
         path: ergo
 

--- a/.github/workflows/solanum.yml
+++ b/.github/workflows/solanum.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        PATH=~/.local/bin:$PATH pytest --controller=irctest.controllers.solanum -k 'not Oragono and not deprecated and not strict and not testDoubleKickMessages'
+        PATH=~/.local/bin:$PATH pytest --controller=irctest.controllers.solanum -k 'not Ergo and not deprecated and not strict and not testDoubleKickMessages'
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ See `irctest/server_tests/test_channel_operations.py` for example.
 Tests for **pending/draft specifications are welcome**.
 
 Note that irctest also welcomes implementation-specific tests for
-functional testing; for now only Oragono.
+functional testing; for now only Ergo.
 This does not relax the requirement on documentating tests.
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-.PHONY: all flakes oragono
+.PHONY: all flakes ergo
 
-all: flakes oragono
+all: flakes ergo
 
 flakes:
-	pyflakes3 ./irctest/cases.py ./irctest/client_mock.py ./irctest/controllers/oragono.py irctest/server_tests/*.py
+	pyflakes3 ./irctest/cases.py ./irctest/client_mock.py ./irctest/controllers/ergo.py irctest/server_tests/*.py
 
 ergo:
 	python3 -m pytest -k "not deprecated" --controller irctest.controllers.ergo

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ all: flakes oragono
 flakes:
 	pyflakes3 ./irctest/cases.py ./irctest/client_mock.py ./irctest/controllers/oragono.py irctest/server_tests/*.py
 
-oragono:
-	python3 -m pytest -k "not deprecated" --controller irctest.controllers.oragono
+ergo:
+	python3 -m pytest -k "not deprecated" --controller irctest.controllers.ergo

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip3 install --user -r requirements.txt pyxmpp2-scram
 python3 setup.py install --user
 ```
 
-Add `~/.local/bin/` (and/or `~/.local/bin/` for Oragono)
+Add `~/.local/bin/` (and/or `~/.local/bin/` for Ergo)
 to your `PATH` if it is not.
 
 ```
@@ -53,10 +53,10 @@ For example, you can run `LUSERS`-related tests with `-k lusers`.
 Or only tests based on RFC1459 with `-k rfc1459`.
 
 By default, all tests run; even niche ones. So you probably always want to
-use these options: `-k 'not Oragono and not deprecated and not strict`.
+use these options: `-k 'not Ergo and not deprecated and not strict`.
 This excludes:
 
-* `Oragono`-specific tests (included as Oragono uses irctest as its official
+* `Ergo`-specific tests (included as Ergo uses irctest as its official
   integration test suite)
 * tests for deprecated specifications, such as the IRCv3 METADATA
   specification
@@ -65,16 +65,15 @@ This excludes:
 
 ## Run tests
 
-To run (server) tests on Oragono:
+To run (server) tests on Ergo:
 
 ```
 cd /tmp/
-git clone https://github.com/oragono/oragono.git
-cd oragono/
-make build
+git clone https://github.com/ergochat/ergo.git
+cd ergo/
 make install
 cd ~/irctest
-pytest --controller irctest.controllers.oragono -k 'not deprecated'
+pytest --controller irctest.controllers.ergo -k 'not deprecated'
 ```
 
 To run (server) tests on Solanum:
@@ -87,7 +86,7 @@ cd charybdis
 ./configure --prefix=$HOME/.local/
 make -j 4
 make install
-pytest --controller irctest.controllers.solanum -k 'not Oragono and not deprecated and not strict'
+pytest --controller irctest.controllers.solanum -k 'not Ergo and not deprecated and not strict'
 ```
 
 To run (server) tests on Charybdis::
@@ -101,7 +100,7 @@ cd charybdis
 make -j 4
 make install
 cd ~/irctest
-pytest --controller irctest.controllers.charybdis -k 'not Oragono and not deprecated and not strict'
+pytest --controller irctest.controllers.charybdis -k 'not Ergo and not deprecated and not strict'
 ```
 
 To run (server) tests on ircd-seven:
@@ -130,7 +129,7 @@ patch src/inspircd.cpp < ../irctest/inspircd_mainloop.patch
 make -j 4
 make install
 cd ~/irctest
-pytest --controller irctest.controllers.inspircd -k 'not Oragono and not deprecated and not strict'
+pytest --controller irctest.controllers.inspircd -k 'not Ergo and not deprecated and not strict'
 ```
 
 To run (server) tests on Mammon:
@@ -138,7 +137,7 @@ To run (server) tests on Mammon:
 ```
 pip3 install --user git+https://github.com/mammon-ircd/mammon.git
 cd ~/irctest
-pytest --controller irctest.controllers.mammon -k 'not Oragono and not deprecated and not strict'
+pytest --controller irctest.controllers.mammon -k 'not Ergo and not deprecated and not strict'
 ```
 
 To run (client) tests on Limnoria:

--- a/irctest/basecontrollers.py
+++ b/irctest/basecontrollers.py
@@ -30,10 +30,10 @@ class TestCaseControllerConfig:
     chathistory: bool = False
     """Whether to enable chathistory features."""
 
-    oragono_roleplay: bool = False
-    """Whether to enable the Oragono role-play commands."""
+    ergo_roleplay: bool = False
+    """Whether to enable the Ergo role-play commands."""
 
-    oragono_config: Optional[Callable[[Dict], Any]] = None
+    ergo_config: Optional[Callable[[Dict], Any]] = None
     """Oragono-specific configuration function that alters the dict in-place
     This should be used as little as possible, using the other attributes instead;
     as they are work with any controller."""

--- a/irctest/controllers/ergo.py
+++ b/irctest/controllers/ergo.py
@@ -14,9 +14,9 @@ from irctest.cases import BaseServerTestCase
 OPER_PWD = "frenchfries"
 
 BASE_CONFIG = {
-    "network": {"name": "OragonoTest"},
+    "network": {"name": "ErgoTest"},
     "server": {
-        "name": "oragono.test",
+        "name": "ergo.test",
         "listeners": {},
         "max-sendq": "16k",
         "connection-limits": {
@@ -133,8 +133,8 @@ def hash_password(password: Union[str, bytes]) -> str:
     return out.decode("utf-8")
 
 
-class OragonoController(BaseServerController, DirectoryBasedController):
-    software_name = "Oragono"
+class ErgoController(BaseServerController, DirectoryBasedController):
+    software_name = "Ergo"
     _port_wait_interval = 0.01
     supported_sasl_mechanisms = {"PLAIN"}
     supports_sts = True
@@ -168,15 +168,15 @@ class OragonoController(BaseServerController, DirectoryBasedController):
         assert self.directory
 
         enable_chathistory = self.test_config.chathistory
-        enable_roleplay = self.test_config.oragono_roleplay
+        enable_roleplay = self.test_config.ergo_roleplay
         if enable_chathistory or enable_roleplay:
             config = self.addMysqlToConfig(config)
 
         if enable_roleplay:
             config["roleplay"] = {"enabled": True}
 
-        if self.test_config.oragono_config:
-            self.test_config.oragono_config(config)
+        if self.test_config.ergo_config:
+            self.test_config.ergo_config(config)
 
         self.port = port
         bind_address = "127.0.0.1:%s" % (port,)
@@ -289,5 +289,5 @@ class OragonoController(BaseServerController, DirectoryBasedController):
         self.rehash(case, config)
 
 
-def get_irctest_controller_class() -> Type[OragonoController]:
-    return OragonoController
+def get_irctest_controller_class() -> Type[ErgoController]:
+    return ErgoController

--- a/irctest/controllers/ergo.py
+++ b/irctest/controllers/ergo.py
@@ -127,7 +127,7 @@ def hash_password(password: Union[str, bytes]) -> str:
     # simulate entry of password and confirmation:
     input_ = password + b"\n" + password + b"\n"
     p = subprocess.Popen(
-        ["oragono", "genpasswd"], stdin=subprocess.PIPE, stdout=subprocess.PIPE
+        ["ergo", "genpasswd"], stdin=subprocess.PIPE, stdout=subprocess.PIPE
     )
     out, _ = p.communicate(input_)
     return out.decode("utf-8")
@@ -199,10 +199,10 @@ class OragonoController(BaseServerController, DirectoryBasedController):
         self._config_path = os.path.join(self.directory, "server.yml")
         self._config = config
         self._write_config()
-        subprocess.call(["oragono", "initdb", "--conf", self._config_path, "--quiet"])
-        subprocess.call(["oragono", "mkcerts", "--conf", self._config_path, "--quiet"])
+        subprocess.call(["ergo", "initdb", "--conf", self._config_path, "--quiet"])
+        subprocess.call(["ergo", "mkcerts", "--conf", self._config_path, "--quiet"])
         self.proc = subprocess.Popen(
-            ["oragono", "run", "--conf", self._config_path, "--quiet"]
+            ["ergo", "run", "--conf", self._config_path, "--quiet"]
         )
 
     def registerUser(
@@ -254,9 +254,9 @@ class OragonoController(BaseServerController, DirectoryBasedController):
         config["datastore"]["mysql"] = {
             "enabled": True,
             "host": "localhost",
-            "user": "oragono",
+            "user": "ergo",
             "password": mysql_password,
-            "history-database": "oragono_history",
+            "history-database": "ergo_history",
             "timeout": "3s",
         }
         config["accounts"]["multiclient"] = {

--- a/irctest/server_tests/test_bouncer.py
+++ b/irctest/server_tests/test_bouncer.py
@@ -5,7 +5,7 @@ from irctest.patma import ANYSTR, StrRe
 
 
 class Bouncer(cases.BaseServerTestCase):
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testBouncer(self):
         """Test basic bouncer functionality."""
         self.controller.registerUser(self, "observer", "observerpassword")

--- a/irctest/server_tests/test_channel_forward.py
+++ b/irctest/server_tests/test_channel_forward.py
@@ -14,7 +14,7 @@ MODERN_CAPS = [
 class ChannelForwarding(cases.BaseServerTestCase):
     """Test the +f channel forwarding mode."""
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testChannelForwarding(self):
         self.connectClient("bar", name="bar", capabilities=MODERN_CAPS)
         self.connectClient("baz", name="baz", capabilities=MODERN_CAPS)

--- a/irctest/server_tests/test_channel_operations.py
+++ b/irctest/server_tests/test_channel_operations.py
@@ -830,7 +830,7 @@ class ChannelQuitTestCase(cases.BaseServerTestCase):
 
 
 class NoCTCPTestCase(cases.BaseServerTestCase):
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testQuit(self):
         self.connectClient("bar")
         self.joinChannel(1, "#chan")
@@ -903,7 +903,7 @@ class KeyTestCase(cases.BaseServerTestCase):
         )
 
         if ERR_INVALIDMODEPARAM in {msg.command for msg in replies}:
-            # First option: ERR_INVALIDMODEPARAM (eg. Oragono)
+            # First option: ERR_INVALIDMODEPARAM (eg. Ergo)
             return
 
         # Second and third options: truncating the key (eg. UnrealIRCd)
@@ -939,7 +939,7 @@ class KeyTestCase(cases.BaseServerTestCase):
 
 
 class AuditoriumTestCase(cases.BaseServerTestCase):
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testAuditorium(self):
         self.connectClient("bar", name="bar", capabilities=MODERN_CAPS)
         self.joinChannel("bar", "#auditorium")
@@ -1123,7 +1123,7 @@ class BanMode(cases.BaseServerTestCase):
         self.sendLine("bar", "JOIN #chan")
         self.assertMessageMatch(self.getMessage("bar"), command="JOIN")
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testCaseInsensitive(self):
         """Some clients allow unsetting modes if their argument matches
         up to normalization"""
@@ -1181,7 +1181,7 @@ class ModeratedMode(cases.BaseServerTestCase):
 
 
 class OpModerated(cases.BaseServerTestCase):
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testOpModerated(self):
         # test the +U channel mode
         self.connectClient("chanop", name="chanop", capabilities=MODERN_CAPS)
@@ -1250,7 +1250,7 @@ class MuteExtban(cases.BaseServerTestCase):
     (f474e7e6dc2d36f96150ebe33b23b4ea76814415) and it is the most popular
     definition so we're going with that one."""
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testISupport(self):
         self.connectClient(1)  # Fetches ISUPPORT
         isupport = self.server_support
@@ -1431,7 +1431,7 @@ class MuteExtban(cases.BaseServerTestCase):
             [msg for msg in replies if msg.command == "PRIVMSG"],
         )
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testCapitalization(self):
         """
         Regression test for oragono #1370: mutes not correctly enforced against

--- a/irctest/server_tests/test_channel_rename.py
+++ b/irctest/server_tests/test_channel_rename.py
@@ -15,7 +15,7 @@ RENAME_CAP = "draft/channel-rename"
 class ChannelRename(cases.BaseServerTestCase):
     """Basic tests for channel-rename."""
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testChannelRename(self):
         self.connectClient("bar", name="bar", capabilities=MODERN_CAPS + [RENAME_CAP])
         self.connectClient("baz", name="baz", capabilities=MODERN_CAPS)

--- a/irctest/server_tests/test_chathistory.py
+++ b/irctest/server_tests/test_chathistory.py
@@ -38,7 +38,7 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(chathistory=True)
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testInvalidTargets(self):
         bar, pw = random_name("bar"), random_name("pw")
         self.controller.registerUser(self, bar, pw)
@@ -79,7 +79,7 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
             params=["CHATHISTORY", "INVALID_TARGET", ANYSTR, ANYSTR],
         )
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testMessagesToSelf(self):
         bar, pw = random_name("bar"), random_name("pw")
         self.controller.registerUser(self, bar, pw)
@@ -143,7 +143,7 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
         self.assertEqual(len(set(msg.msgid for msg in echo_messages)), num_messages)
         self.assertEqual(len(set(msg.time for msg in echo_messages)), num_messages)
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testChathistory(self):
         self.connectClient(
             "bar",
@@ -173,7 +173,7 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
         self.validate_echo_messages(NUM_MESSAGES, echo_messages)
         self.validate_chathistory(echo_messages, 1, chname)
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testChathistoryDMs(self):
         c1 = secrets.token_hex(12)
         c2 = secrets.token_hex(12)
@@ -483,7 +483,7 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
         result = validate_chathistory_batch(self.getMessages(user))
         self.assertIn(echo_messages[7], result)
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testChathistoryTagmsg(self):
         c1 = secrets.token_hex(12)
         c2 = secrets.token_hex(12)
@@ -577,9 +577,9 @@ class ChathistoryTestCase(cases.BaseServerTestCase):
         ]
         self.assertEqual(len(history_tagmsgs), 0)
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testChathistoryDMClientOnlyTags(self):
-        # regression test for Oragono #1411
+        # regression test for Ergo #1411
         c1 = secrets.token_hex(12)
         c2 = secrets.token_hex(12)
         self.controller.registerUser(self, c1, "sesame1")

--- a/irctest/server_tests/test_confusables.py
+++ b/irctest/server_tests/test_confusables.py
@@ -6,12 +6,12 @@ class ConfusablesTestCase(cases.BaseServerTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(
-            oragono_config=lambda config: config["accounts"].update(
+            ergo_config=lambda config: config["accounts"].update(
                 {"nick-reservation": {"enabled": True, "method": "strict"}}
             )
         )
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testConfusableNicks(self):
         self.controller.registerUser(self, "evan", "sesame")
 

--- a/irctest/server_tests/test_lusers.py
+++ b/irctest/server_tests/test_lusers.py
@@ -180,12 +180,12 @@ class LusersUnregisteredDefaultInvisibleTest(LusersUnregisteredTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(
-            oragono_config=lambda config: config["accounts"].update(
+            ergo_config=lambda config: config["accounts"].update(
                 {"default-user-modes": "+i"}
             )
         )
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testLusers(self):
         self.doLusersTest()
         lusers = self.getLusers("bar")
@@ -195,7 +195,7 @@ class LusersUnregisteredDefaultInvisibleTest(LusersUnregisteredTestCase):
 
 
 class LuserOpersTest(LusersTestCase):
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testLuserOpers(self):
         self.connectClient("bar", name="bar")
         lusers = self.getLusers("bar")
@@ -238,12 +238,12 @@ class OragonoInvisibleDefaultTest(LusersTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(
-            oragono_config=lambda config: config["accounts"].update(
+            ergo_config=lambda config: config["accounts"].update(
                 {"default-user-modes": "+i"}
             )
         )
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testLusers(self):
         self.connectClient("bar", name="bar")
         lusers = self.getLusers("bar")

--- a/irctest/server_tests/test_messages.py
+++ b/irctest/server_tests/test_messages.py
@@ -82,7 +82,7 @@ class TagsTestCase(cases.BaseServerTestCase):
 
 
 class LengthLimitTestCase(cases.BaseServerTestCase):
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testLineAtLimit(self):
         self.connectClient("bar", name="bar")
         self.getMessages("bar")
@@ -97,7 +97,7 @@ class LengthLimitTestCase(cases.BaseServerTestCase):
         self.assertMessageMatch(result, command="PONG")
         self.assertIn("x" * 450, result.params[-1])
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testLineBeyondLimit(self):
         self.connectClient("bar", name="bar")
         self.getMessages("bar")

--- a/irctest/server_tests/test_readq.py
+++ b/irctest/server_tests/test_readq.py
@@ -4,7 +4,7 @@ from irctest import cases
 class ReadqTestCase(cases.BaseServerTestCase):
     """Test responses to DoS attacks using long lines."""
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     @cases.mark_capabilities("message-tags")
     def testReadqTags(self):
         self.connectClient("mallory", name="mallory", capabilities=["message-tags"])
@@ -12,7 +12,7 @@ class ReadqTestCase(cases.BaseServerTestCase):
         self.sendLine("mallory", "PRIVMSG #test " + "a" * 16384)
         self.assertDisconnected("mallory")
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testReadqNoTags(self):
         self.connectClient("mallory", name="mallory")
         self.joinChannel("mallory", "#test")

--- a/irctest/server_tests/test_register_verify.py
+++ b/irctest/server_tests/test_register_verify.py
@@ -8,12 +8,12 @@ class TestRegisterBeforeConnect(cases.BaseServerTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(
-            oragono_config=lambda config: config["accounts"]["registration"].update(
+            ergo_config=lambda config: config["accounts"]["registration"].update(
                 {"allow-before-connect": True}
             )
         )
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testBeforeConnect(self):
         self.addClient("bar")
         self.sendLine("bar", "CAP LS 302")
@@ -31,12 +31,12 @@ class TestRegisterBeforeConnectDisallowed(cases.BaseServerTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(
-            oragono_config=lambda config: config["accounts"]["registration"].update(
+            ergo_config=lambda config: config["accounts"]["registration"].update(
                 {"allow-before-connect": False}
             )
         )
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testBeforeConnect(self):
         self.addClient("bar")
         self.sendLine("bar", "CAP LS 302")
@@ -57,7 +57,7 @@ class TestRegisterEmailVerified(cases.BaseServerTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(
-            oragono_config=lambda config: config["accounts"]["registration"].update(
+            ergo_config=lambda config: config["accounts"]["registration"].update(
                 {
                     "email-verification": {
                         "enabled": True,
@@ -70,7 +70,7 @@ class TestRegisterEmailVerified(cases.BaseServerTestCase):
             )
         )
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testBeforeConnect(self):
         self.addClient("bar")
         self.sendLine("bar", "CAP LS 302")
@@ -88,7 +88,7 @@ class TestRegisterEmailVerified(cases.BaseServerTestCase):
             fail_response, params=["REGISTER", "INVALID_EMAIL", ANYSTR, ANYSTR]
         )
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testAfterConnect(self):
         self.connectClient("bar", name="bar")
         self.sendLine("bar", "REGISTER * shivarampassphrase")
@@ -103,12 +103,12 @@ class TestRegisterNoLandGrabs(cases.BaseServerTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(
-            oragono_config=lambda config: config["accounts"]["registration"].update(
+            ergo_config=lambda config: config["accounts"]["registration"].update(
                 {"allow-before-connect": True}
             )
         )
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testBeforeConnect(self):
         # have an anonymous client take the 'root' username:
         self.connectClient("root", name="root")

--- a/irctest/server_tests/test_relaymsg.py
+++ b/irctest/server_tests/test_relaymsg.py
@@ -12,7 +12,7 @@ class RelaymsgTestCase(cases.BaseServerTestCase):
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(chathistory=True)
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testRelaymsg(self):
         self.connectClient(
             "baz",

--- a/irctest/server_tests/test_roleplay.py
+++ b/irctest/server_tests/test_roleplay.py
@@ -7,9 +7,9 @@ from irctest.patma import StrRe
 class RoleplayTestCase(cases.BaseServerTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
-        return cases.TestCaseControllerConfig(oragono_roleplay=True)
+        return cases.TestCaseControllerConfig(ergo_roleplay=True)
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testRoleplay(self):
         bar = random_name("bar")
         qux = random_name("qux")

--- a/irctest/server_tests/test_statusmsg.py
+++ b/irctest/server_tests/test_statusmsg.py
@@ -3,7 +3,7 @@ from irctest.numerics import RPL_NAMREPLY
 
 
 class StatusmsgTestCase(cases.BaseServerTestCase):
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testInIsupport(self):
         """Check that the expected STATUSMSG parameter appears in our isupport list."""
         self.connectClient("foo")  # detects ISUPPORT

--- a/irctest/server_tests/test_user_commands.py
+++ b/irctest/server_tests/test_user_commands.py
@@ -40,7 +40,7 @@ class WhoisTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
         )
         self.assertEqual(whois_user.params[5], realname)
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testInvisibleWhois(self):
         """Test interaction between MODE +i and RPL_WHOISCHANNELS."""
         self.connectClient("userOne")
@@ -167,7 +167,7 @@ class AwayTestCase(cases.BaseServerTestCase):
 
 
 class TestNoCTCPMode(cases.BaseServerTestCase):
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testNoCTCPMode(self):
         self.connectClient("bar", "bar")
         self.connectClient("qux", "qux")

--- a/irctest/server_tests/test_utf8.py
+++ b/irctest/server_tests/test_utf8.py
@@ -3,7 +3,7 @@ from irctest.patma import ANYSTR
 
 
 class Utf8TestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testUtf8Validation(self):
         self.connectClient(
             "bar",

--- a/irctest/server_tests/test_znc_playback.py
+++ b/irctest/server_tests/test_znc_playback.py
@@ -18,7 +18,7 @@ class ZncPlaybackTestCase(cases.BaseServerTestCase):
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(chathistory=True)
 
-    @cases.mark_specifications("Oragono")
+    @cases.mark_specifications("Ergo")
     def testZncPlayback(self):
         early_time = int(time.time() - 60)
 

--- a/irctest/specifications.py
+++ b/irctest/specifications.py
@@ -8,7 +8,7 @@ class Specifications(enum.Enum):
     RFC1459 = "RFC1459"
     RFC2812 = "RFC2812"
     IRCv3 = "IRCv3"  # Mark with capabilities whenever possible
-    Oragono = "Oragono"
+    Ergo = "Ergo"
 
     Ircdocs = "ircdocs"
     """Any document on ircdocs.horse (especially defs.ircdocs.horse),

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,7 +6,7 @@ markers =
     IRCv3
     modern
     ircdocs
-    Oragono
+    Ergo
 
     # misc marks
     strict


### PR DESCRIPTION
Remaining references in `git grep -i oragono` are historical.