### PR TITLE
Split Unreal/Insp's tests between Atheme and serviceless

### DIFF
--- a/.github/workflows/test-devel.yml
+++ b/.github/workflows/test-devel.yml
@@ -148,8 +148,10 @@ jobs:
     - test-solanum
     - test-ergo
     - test-inspircd
+    - test-inspircd-atheme
     - test-inspircd-anope
     - test-unrealircd
+    - test-unrealircd-atheme
     - test-unrealircd-anope
     - test-limnoria
     - test-sopel
@@ -304,6 +306,38 @@ jobs:
       with:
         name: pytest results anope (devel)
         path: pytest.xml
+  test-inspircd-atheme:
+    needs:
+    - build-inspircd
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Download build artefacts
+      uses: actions/download-artifact@v2
+      with:
+        name: installed-inspircd
+        path: '~'
+    - name: Unpack artefacts
+      run: cd ~; find -name 'artefacts-*.tar.gz' -exec tar -xzf '{}' \;
+    - name: Install Atheme
+      run: sudo apt-get install atheme-services
+    - name: Install irctest dependencies
+      run: |-
+        python -m pip install --upgrade pip
+        pip install pytest -r requirements.txt
+    - name: Test with pytest
+      run: PYTEST_ARGS='--junit-xml pytest.xml' PATH=$HOME/.local/bin:$PATH PYTEST_ARGS="$PYTEST_ARGS
+        -m 'not services'" PATH=~/.local/inspircd/bin:$PATH make inspircd-atheme
+    - if: always()
+      name: Publish results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pytest results inspircd (devel)
+        path: pytest.xml
   test-limnoria:
     needs: []
     runs-on: ubuntu-latest
@@ -457,6 +491,38 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: pytest results anope (devel)
+        path: pytest.xml
+  test-unrealircd-atheme:
+    needs:
+    - build-unrealircd
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Download build artefacts
+      uses: actions/download-artifact@v2
+      with:
+        name: installed-unrealircd
+        path: '~'
+    - name: Unpack artefacts
+      run: cd ~; find -name 'artefacts-*.tar.gz' -exec tar -xzf '{}' \;
+    - name: Install Atheme
+      run: sudo apt-get install atheme-services
+    - name: Install irctest dependencies
+      run: |-
+        python -m pip install --upgrade pip
+        pip install pytest -r requirements.txt
+    - name: Test with pytest
+      run: PYTEST_ARGS='--junit-xml pytest.xml' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/unrealircd/bin:$PATH
+        make unrealircd-atheme
+    - if: always()
+      name: Publish results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pytest results unrealircd (devel)
         path: pytest.xml
 name: irctest with devel versions
 'on':

--- a/.github/workflows/test-devel.yml
+++ b/.github/workflows/test-devel.yml
@@ -304,7 +304,7 @@ jobs:
       name: Publish results
       uses: actions/upload-artifact@v2
       with:
-        name: pytest results anope (devel)
+        name: pytest results inspircd-anope (devel)
         path: pytest.xml
   test-inspircd-atheme:
     needs:
@@ -336,7 +336,7 @@ jobs:
       name: Publish results
       uses: actions/upload-artifact@v2
       with:
-        name: pytest results inspircd (devel)
+        name: pytest results inspircd-atheme (devel)
         path: pytest.xml
   test-limnoria:
     needs: []
@@ -490,7 +490,7 @@ jobs:
       name: Publish results
       uses: actions/upload-artifact@v2
       with:
-        name: pytest results anope (devel)
+        name: pytest results unrealircd-anope (devel)
         path: pytest.xml
   test-unrealircd-atheme:
     needs:
@@ -522,7 +522,7 @@ jobs:
       name: Publish results
       uses: actions/upload-artifact@v2
       with:
-        name: pytest results unrealircd (devel)
+        name: pytest results unrealircd-atheme (devel)
         path: pytest.xml
 name: irctest with devel versions
 'on':

--- a/.github/workflows/test-devel_release.yml
+++ b/.github/workflows/test-devel_release.yml
@@ -209,7 +209,7 @@ jobs:
       name: Publish results
       uses: actions/upload-artifact@v2
       with:
-        name: pytest results anope (devel_release)
+        name: pytest results inspircd-anope (devel_release)
         path: pytest.xml
   test-inspircd-atheme:
     needs:
@@ -241,7 +241,7 @@ jobs:
       name: Publish results
       uses: actions/upload-artifact@v2
       with:
-        name: pytest results inspircd (devel_release)
+        name: pytest results inspircd-atheme (devel_release)
         path: pytest.xml
   test-limnoria:
     needs: []
@@ -391,7 +391,7 @@ jobs:
       name: Publish results
       uses: actions/upload-artifact@v2
       with:
-        name: pytest results anope (devel_release)
+        name: pytest results unrealircd-anope (devel_release)
         path: pytest.xml
   test-unrealircd-atheme:
     needs:
@@ -423,7 +423,7 @@ jobs:
       name: Publish results
       uses: actions/upload-artifact@v2
       with:
-        name: pytest results unrealircd (devel_release)
+        name: pytest results unrealircd-atheme (devel_release)
         path: pytest.xml
 name: irctest with devel_release versions
 'on':

--- a/.github/workflows/test-devel_release.yml
+++ b/.github/workflows/test-devel_release.yml
@@ -68,8 +68,10 @@ jobs:
     - test-solanum
     - test-ergo
     - test-inspircd
+    - test-inspircd-atheme
     - test-inspircd-anope
     - test-unrealircd
+    - test-unrealircd-atheme
     - test-unrealircd-anope
     - test-limnoria
     - test-sopel
@@ -208,6 +210,38 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: pytest results anope (devel_release)
+        path: pytest.xml
+  test-inspircd-atheme:
+    needs:
+    - build-inspircd
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Download build artefacts
+      uses: actions/download-artifact@v2
+      with:
+        name: installed-inspircd
+        path: '~'
+    - name: Unpack artefacts
+      run: cd ~; find -name 'artefacts-*.tar.gz' -exec tar -xzf '{}' \;
+    - name: Install Atheme
+      run: sudo apt-get install atheme-services
+    - name: Install irctest dependencies
+      run: |-
+        python -m pip install --upgrade pip
+        pip install pytest -r requirements.txt
+    - name: Test with pytest
+      run: PYTEST_ARGS='--junit-xml pytest.xml' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/inspircd/bin:$PATH
+        make inspircd-atheme
+    - if: always()
+      name: Publish results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pytest results inspircd (devel_release)
         path: pytest.xml
   test-limnoria:
     needs: []
@@ -358,6 +392,38 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: pytest results anope (devel_release)
+        path: pytest.xml
+  test-unrealircd-atheme:
+    needs:
+    - build-unrealircd
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Download build artefacts
+      uses: actions/download-artifact@v2
+      with:
+        name: installed-unrealircd
+        path: '~'
+    - name: Unpack artefacts
+      run: cd ~; find -name 'artefacts-*.tar.gz' -exec tar -xzf '{}' \;
+    - name: Install Atheme
+      run: sudo apt-get install atheme-services
+    - name: Install irctest dependencies
+      run: |-
+        python -m pip install --upgrade pip
+        pip install pytest -r requirements.txt
+    - name: Test with pytest
+      run: PYTEST_ARGS='--junit-xml pytest.xml' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/unrealircd/bin:$PATH
+        make unrealircd-atheme
+    - if: always()
+      name: Publish results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pytest results unrealircd (devel_release)
         path: pytest.xml
 name: irctest with devel_release versions
 'on':

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -186,8 +186,10 @@ jobs:
     - test-solanum
     - test-ergo
     - test-inspircd
+    - test-inspircd-atheme
     - test-inspircd-anope
     - test-unrealircd
+    - test-unrealircd-atheme
     - test-unrealircd-anope
     - test-limnoria
     - test-sopel
@@ -342,6 +344,38 @@ jobs:
       with:
         name: pytest results anope (stable)
         path: pytest.xml
+  test-inspircd-atheme:
+    needs:
+    - build-inspircd
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Download build artefacts
+      uses: actions/download-artifact@v2
+      with:
+        name: installed-inspircd
+        path: '~'
+    - name: Unpack artefacts
+      run: cd ~; find -name 'artefacts-*.tar.gz' -exec tar -xzf '{}' \;
+    - name: Install Atheme
+      run: sudo apt-get install atheme-services
+    - name: Install irctest dependencies
+      run: |-
+        python -m pip install --upgrade pip
+        pip install pytest -r requirements.txt
+    - name: Test with pytest
+      run: PYTEST_ARGS='--junit-xml pytest.xml' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/inspircd/bin:$PATH
+        make inspircd-atheme
+    - if: always()
+      name: Publish results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pytest results inspircd (stable)
+        path: pytest.xml
   test-limnoria:
     needs: []
     runs-on: ubuntu-latest
@@ -495,6 +529,38 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: pytest results anope (stable)
+        path: pytest.xml
+  test-unrealircd-atheme:
+    needs:
+    - build-unrealircd
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Download build artefacts
+      uses: actions/download-artifact@v2
+      with:
+        name: installed-unrealircd
+        path: '~'
+    - name: Unpack artefacts
+      run: cd ~; find -name 'artefacts-*.tar.gz' -exec tar -xzf '{}' \;
+    - name: Install Atheme
+      run: sudo apt-get install atheme-services
+    - name: Install irctest dependencies
+      run: |-
+        python -m pip install --upgrade pip
+        pip install pytest -r requirements.txt
+    - name: Test with pytest
+      run: PYTEST_ARGS='--junit-xml pytest.xml' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/unrealircd/bin:$PATH
+        make unrealircd-atheme
+    - if: always()
+      name: Publish results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pytest results unrealircd (stable)
         path: pytest.xml
 name: irctest with stable versions
 'on':

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -342,7 +342,7 @@ jobs:
       name: Publish results
       uses: actions/upload-artifact@v2
       with:
-        name: pytest results anope (stable)
+        name: pytest results inspircd-anope (stable)
         path: pytest.xml
   test-inspircd-atheme:
     needs:
@@ -374,7 +374,7 @@ jobs:
       name: Publish results
       uses: actions/upload-artifact@v2
       with:
-        name: pytest results inspircd (stable)
+        name: pytest results inspircd-atheme (stable)
         path: pytest.xml
   test-limnoria:
     needs: []
@@ -528,7 +528,7 @@ jobs:
       name: Publish results
       uses: actions/upload-artifact@v2
       with:
-        name: pytest results anope (stable)
+        name: pytest results unrealircd-anope (stable)
         path: pytest.xml
   test-unrealircd-atheme:
     needs:
@@ -560,7 +560,7 @@ jobs:
       name: Publish results
       uses: actions/upload-artifact@v2
       with:
-        name: pytest results unrealircd (stable)
+        name: pytest results unrealircd-atheme (stable)
         path: pytest.xml
 name: irctest with stable versions
 'on':

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,14 @@ ergo:
 inspircd:
 	$(PYTEST) $(PYTEST_ARGS) \
 		--controller=irctest.controllers.inspircd \
+		-m 'not services' \
+		-k '$(INSPIRCD_SELECTORS)'
+
+inspircd-atheme:
+	$(PYTEST) $(PYTEST_ARGS) \
+		--controller=irctest.controllers.inspircd \
 		--services-controller=irctest.controllers.atheme_services \
+		-m 'services' \
 		-k '$(INSPIRCD_SELECTORS)'
 
 inspircd-anope:
@@ -145,7 +152,14 @@ sopel:
 unrealircd:
 	$(PYTEST) $(PYTEST_ARGS) \
 		--controller=irctest.controllers.unrealircd \
+		-m 'not services' \
+		-k '$(UNREALIRCD_SELECTORS)'
+
+unrealircd-atheme:
+	$(PYTEST) $(PYTEST_ARGS) \
+		--controller=irctest.controllers.unrealircd \
 		--services-controller=irctest.controllers.atheme_services \
+		-m 'services' \
 		-k '$(UNREALIRCD_SELECTORS)'
 
 unrealircd-anope:

--- a/make_workflows.py
+++ b/make_workflows.py
@@ -223,7 +223,7 @@ def get_test_job(*, config, test_config, test_id, version_flavor):
                 "if": "always()",
                 "uses": "actions/upload-artifact@v2",
                 "with": {
-                    "name": f"pytest results {software_id} ({version_flavor.value})",
+                    "name": f"pytest results {test_id} ({version_flavor.value})",
                     "path": "pytest.xml",
                 },
             },

--- a/workflows.yml
+++ b/workflows.yml
@@ -155,10 +155,16 @@ tests:
     inspircd:
         software: [inspircd]
 
+    inspircd-atheme:
+        software: [inspircd]
+
     inspircd-anope:
         software: [inspircd, anope]
 
     unrealircd:
+        software: [unrealircd]
+
+    unrealircd-atheme:
         software: [unrealircd]
 
     unrealircd-anope:


### PR DESCRIPTION
it should make the critical path (insp) slightly shorter