### PR TITLE
disable SCRAM in ergo tests

### DIFF
--- a/irctest/controllers/ergo.py
+++ b/irctest/controllers/ergo.py
@@ -136,7 +136,7 @@ def hash_password(password: Union[str, bytes]) -> str:
 class ErgoController(BaseServerController, DirectoryBasedController):
     software_name = "Ergo"
     _port_wait_interval = 0.01
-    supported_sasl_mechanisms = {"PLAIN", "SCRAM-SHA-256"}
+    supported_sasl_mechanisms = {"PLAIN"}
     supports_sts = True
     extban_mute_char = "m"
 


### PR DESCRIPTION
Advertising SCRAM breaks irccloud, so the advertisement has to be disabled,
so remove it from the controller.