### PR TITLE
fix some tests not being discovered due to their class names

### DIFF
--- a/irctest/server_tests/bouncer.py
+++ b/irctest/server_tests/bouncer.py
@@ -5,7 +5,7 @@ from irctest.patma import ANYSTR, StrRe
 
 
 @cases.mark_services
-class Bouncer(cases.BaseServerTestCase):
+class BouncerTestCase(cases.BaseServerTestCase):
     @cases.mark_specifications("Ergo")
     def testBouncer(self):
         """Test basic bouncer functionality."""

--- a/irctest/server_tests/channel.py
+++ b/irctest/server_tests/channel.py
@@ -3,7 +3,7 @@ import pytest
 from irctest import cases, client_mock, runner
 
 
-class TestChannelCaseSensitivity(cases.BaseServerTestCase):
+class ChannelCaseSensitivityTestCase(cases.BaseServerTestCase):
     @pytest.mark.parametrize(
         "casemapping,name1,name2",
         [

--- a/irctest/server_tests/channel_forward.py
+++ b/irctest/server_tests/channel_forward.py
@@ -11,7 +11,7 @@ MODERN_CAPS = [
 ]
 
 
-class ChannelForwarding(cases.BaseServerTestCase):
+class ChannelForwardingTestCase(cases.BaseServerTestCase):
     """Test the +f channel forwarding mode."""
 
     @cases.mark_specifications("Ergo")

--- a/irctest/server_tests/channel_rename.py
+++ b/irctest/server_tests/channel_rename.py
@@ -12,7 +12,7 @@ MODERN_CAPS = [
 RENAME_CAP = "draft/channel-rename"
 
 
-class ChannelRename(cases.BaseServerTestCase):
+class ChannelRenameTestCase(cases.BaseServerTestCase):
     """Basic tests for channel-rename."""
 
     @cases.mark_specifications("Ergo")

--- a/irctest/server_tests/lusers.py
+++ b/irctest/server_tests/lusers.py
@@ -110,7 +110,7 @@ class LusersTestCase(cases.BaseServerTestCase):
         return result
 
 
-class BasicLusersTest(LusersTestCase):
+class BasicLusersTestCase(LusersTestCase):
     @cases.mark_specifications("RFC2812")
     def testLusers(self):
         self.connectClient("bar", name="bar")
@@ -175,7 +175,7 @@ class LusersUnregisteredTestCase(LusersTestCase):
         self.assertLusersResult(lusers, unregistered=0, total=2, max_=2)
 
 
-class LusersUnregisteredDefaultInvisibleTest(LusersUnregisteredTestCase):
+class LusersUnregisteredDefaultInvisibleTestCase(LusersUnregisteredTestCase):
     """Same as above but with +i as the default."""
 
     @staticmethod
@@ -195,7 +195,7 @@ class LusersUnregisteredDefaultInvisibleTest(LusersUnregisteredTestCase):
         self.assertEqual(lusers.GlobalVisible, 0)
 
 
-class LuserOpersTest(LusersTestCase):
+class LuserOpersTestCase(LusersTestCase):
     @cases.mark_specifications("Ergo")
     def testLuserOpers(self):
         self.connectClient("bar", name="bar")
@@ -204,7 +204,7 @@ class LuserOpersTest(LusersTestCase):
         self.assertIn(lusers.Opers, (0, None))
 
         # add 1 oper
-        self.sendLine("bar", "OPER root frenchfries")
+        self.sendLine("bar", "OPER operuser operpassword")
         msgs = self.getMessages("bar")
         self.assertIn(RPL_YOUREOPER, {msg.command for msg in msgs})
         lusers = self.getLusers("bar")
@@ -213,7 +213,7 @@ class LuserOpersTest(LusersTestCase):
 
         # now 2 opers
         self.connectClient("qux", name="qux")
-        self.sendLine("qux", "OPER root frenchfries")
+        self.sendLine("qux", "OPER operuser operpassword")
         self.getMessages("qux")
         lusers = self.getLusers("bar")
         self.assertLusersResult(lusers, unregistered=0, total=2, max_=2)
@@ -235,7 +235,7 @@ class LuserOpersTest(LusersTestCase):
         self.assertEqual(lusers.Opers, 0)
 
 
-class OragonoInvisibleDefaultTest(LusersTestCase):
+class ErgoInvisibleDefaultTestCase(LusersTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(

--- a/irctest/server_tests/messages.py
+++ b/irctest/server_tests/messages.py
@@ -116,7 +116,7 @@ class LengthLimitTestCase(cases.BaseServerTestCase):
         self.joinChannel("bar", "#test_channel")
 
 
-class TestNoCTCPMode(cases.BaseServerTestCase):
+class NoCTCPModeTestCase(cases.BaseServerTestCase):
     @cases.mark_specifications("Ergo")
     def testNoCTCPMode(self):
         self.connectClient("bar", "bar")

--- a/irctest/server_tests/register_verify.py
+++ b/irctest/server_tests/register_verify.py
@@ -5,7 +5,7 @@ REGISTER_CAP_NAME = "draft/account-registration"
 
 
 @cases.mark_specifications("IRCv3")
-class TestRegisterBeforeConnect(cases.BaseServerTestCase):
+class RegisterBeforeConnectTestCase(cases.BaseServerTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(
@@ -29,7 +29,7 @@ class TestRegisterBeforeConnect(cases.BaseServerTestCase):
 
 
 @cases.mark_specifications("IRCv3")
-class TestRegisterBeforeConnectDisallowed(cases.BaseServerTestCase):
+class RegisterBeforeConnectDisallowedTestCase(cases.BaseServerTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(
@@ -56,7 +56,7 @@ class TestRegisterBeforeConnectDisallowed(cases.BaseServerTestCase):
 
 
 @cases.mark_specifications("IRCv3")
-class TestRegisterEmailVerified(cases.BaseServerTestCase):
+class RegisterEmailVerifiedTestCase(cases.BaseServerTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(
@@ -106,7 +106,7 @@ class TestRegisterEmailVerified(cases.BaseServerTestCase):
 
 
 @cases.mark_specifications("IRCv3", "Ergo")
-class TestRegisterNoLandGrabs(cases.BaseServerTestCase):
+class RegisterNoLandGrabsTestCase(cases.BaseServerTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(

--- a/irctest/server_tests/topic.py
+++ b/irctest/server_tests/topic.py
@@ -149,7 +149,7 @@ class TopicTestCase(cases.BaseServerTestCase):
         self.assertNotIn(RPL_NOTOPIC, [m.command for m in messages])
 
 
-class TopicPrivileges(cases.BaseServerTestCase):
+class TopicPrivilegesTestCase(cases.BaseServerTestCase):
     @cases.mark_specifications("RFC2812")
     def testTopicPrivileges(self):
         # test the +t channel mode, which prevents unprivileged users


### PR DESCRIPTION
Follow up from #112

Before: ` 243 passed, 5 skipped, 16 deselected in 23.28 seconds `
After: ` 251 passed, 5 skipped, 16 deselected in 25.75 seconds`