### PR TITLE
Add tests for PRIVMSG to a server mask

### DIFF
--- a/irctest/controllers/inspircd.py
+++ b/irctest/controllers/inspircd.py
@@ -22,7 +22,7 @@ TEMPLATE_CONFIG = """
 <class
     name="ServerOperators"
     commands="WALLOPS GLOBOPS"
-    privs="channels/auspex users/auspex channels/auspex servers/auspex"
+    privs="channels/auspex users/auspex channels/auspex servers/auspex users/mass-message"
     >
 <type
     name="NetAdmin"


### PR DESCRIPTION
https://github.com/ircdocs/modern-irc/pull/134

A bunch of tests are failing, we need to work this out in the Modern PR

Note: it needs the following patch to plexus4 to be relevant:

```diff
diff --git a/modules/core/m_message.c b/modules/core/m_message.c
index adf0821..7568f20 100644
--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -575,7 +575,7 @@ handle_special(int p_or_n, const char *command, struct Client *client_p,
       return;
     }

-    if (MyClient(source_p) && !HasUMode(source_p, UMODE_NETADMIN) && !HasFlag(source_p, FLAGS_SERVICE) && strcmp(nick + 1, me.name))
+    if (false)
     {
       sendto_one(source_p, form_str(ERR_NOPRIVILEGES), me.name, source_p->name);
       return;
```

(I'm too lazy to figure out how to become a netadmin)