### PR TITLE
silent.py Tests channels with mode +s not appearing in LIST unless the user is a member of that channel.

### DIFF
--- a/irctest/server_tests/chmodes/silent.py
+++ b/irctest/server_tests/chmodes/silent.py
@@ -1,0 +1,46 @@
+from irctest import cases
+from irctest.numerics import RPL_LIST
+
+# RPL_LIST = "322"
+
+class SilentWhileJoinedListModeTestCase(cases.BaseServerTestCase):
+    @cases.mark_specifications("RFC1459", "RFC2812")
+    def testSilentChannelWhileJoined(self):
+        # test that a silent channel is shown in list if the user is in the channel.
+        self.connectClient("first", name="first")
+        self.joinChannel("first", "#gen")
+        self.getMessages("first")
+        self.sendLine("first", "MODE #gen +s")
+        # mode +s = secret, channel shouldn't show
+        # in /quote list UNLESS the user is
+        # in the channel.
+
+        # run command LIST
+        # if the daemon works correctly, it will reply with
+        # , among other things, a 322 (RPL_LIST) line which
+        # contains the one channel just created.
+        self.sendLine("first", "LIST")
+        replies = self.getMessages("first")
+        reply_cmds = {reply.command for reply in replies}
+        self.assertIn(RPL_LIST, reply_cmds)
+
+        # test that another client would not see the secret
+        # channel.
+        self.connectClient("second", name="second")
+        self.getMessages("second")
+        self.sendLine("second", "LIST")
+        replies = self.getMessages("second")
+        reply_cmds = {reply.command for reply in replies}
+        # RPL_LIST 322 should NOT be present this time.
+        self.assertNotIn(RPL_LIST, reply_cmds)
+
+        # Second client will join the secret channel
+        # and call command LIST. The channel SHOULD
+        # appear this time.
+        self.joinChannel("second", "#gen")
+        self.sendLine("second", "LIST")
+        replies = self.getMessages("second")
+        reply_cmds = {reply.command for reply in replies}
+        self.assertIn(RPL_LIST, reply_cmds)
+        
+        

--- a/irctest/server_tests/chmodes/silent.py
+++ b/irctest/server_tests/chmodes/silent.py
@@ -11,18 +11,19 @@ class SilentWhileJoinedListModeTestCase(cases.BaseServerTestCase):
         self.joinChannel("first", "#gen")
         self.getMessages("first")
         self.sendLine("first", "MODE #gen +s")
-        # mode +s = secret, channel shouldn't show
-        # in /quote list UNLESS the user is
-        # in the channel.
-
         # run command LIST
-        # if the daemon works correctly, it will reply with
-        # , among other things, a 322 (RPL_LIST) line which
-        # contains the one channel just created.
         self.sendLine("first", "LIST")
         replies = self.getMessages("first")
-        reply_cmds = {reply.command for reply in replies}
-        self.assertIn(RPL_LIST, reply_cmds)
+
+        # Should be only one line with command RPL_LIST
+        listedChannels = [line for line in replies if line.command == RPL_LIST]
+        # Just one channel in list.
+        self.assertEqual(len(listedChannels), 1)
+        # Check that the channel is reported properly
+        self.assertMessageMatch(
+                listedChannels[0], command=RPL_LIST,
+                params=["first", "#gen", "1", ""]
+                )
 
         # test that another client would not see the secret
         # channel.
@@ -32,7 +33,8 @@ class SilentWhileJoinedListModeTestCase(cases.BaseServerTestCase):
         replies = self.getMessages("second")
         reply_cmds = {reply.command for reply in replies}
         # RPL_LIST 322 should NOT be present this time.
-        self.assertNotIn(RPL_LIST, reply_cmds)
+        listedChannels = [line for line in replies if line.command == RPL_LIST]
+        self.assertEqual(len(listedChannels), 0)
 
         # Second client will join the secret channel
         # and call command LIST. The channel SHOULD
@@ -40,7 +42,13 @@ class SilentWhileJoinedListModeTestCase(cases.BaseServerTestCase):
         self.joinChannel("second", "#gen")
         self.sendLine("second", "LIST")
         replies = self.getMessages("second")
-        reply_cmds = {reply.command for reply in replies}
-        self.assertIn(RPL_LIST, reply_cmds)
-        
+        # Should be only one line with command RPL_LIST
+        listedChannels = [line for line in replies if line.command == RPL_LIST]
+        # Just one channel in list.
+        self.assertEqual(len(listedChannels), 1)
+        # Check that the channel is reported properly
+        self.assertMessageMatch(
+                listedChannels[0], command=RPL_LIST,
+                params=["second", "#gen", "2", ""]
+                )
         


### PR DESCRIPTION
Tests for intended behavior as described in title. Was just patched in ergo commit https://github.com/ergochat/ergo/commit/4010f3fc02bfe3914188d723fc7e16cda9043b0d

Let me know if this is missing anything or what other tests this should cover. Thanks!