### PR TITLE
testWrongPassword: Add stricter check of the reply's command

### DIFF
--- a/irctest/server_tests/connection_registration.py
+++ b/irctest/server_tests/connection_registration.py
@@ -5,7 +5,7 @@ Tests section 4.1 of RFC 1459.
 
 from irctest import cases
 from irctest.client_mock import ConnectionClosed
-from irctest.numerics import ERR_NEEDMOREPARAMS
+from irctest.numerics import ERR_NEEDMOREPARAMS, ERR_PASSWDMISMATCH
 from irctest.patma import ANYSTR, StrRe
 
 
@@ -46,6 +46,7 @@ class PasswordedConnectionRegistrationTestCase(cases.BaseServerTestCase):
         self.assertNotEqual(
             m.command, "001", msg="Got 001 after NICK+USER but incorrect PASS"
         )
+        self.assertIn(m.command, {ERR_PASSWDMISMATCH, "ERROR"})
 
     @cases.mark_specifications("RFC1459", "RFC2812", strict=True)
     def testPassAfterNickuser(self):

--- a/irctest/server_tests/connection_registration.py
+++ b/irctest/server_tests/connection_registration.py
@@ -48,6 +48,12 @@ class PasswordedConnectionRegistrationTestCase(cases.BaseServerTestCase):
         )
         self.assertIn(m.command, {ERR_PASSWDMISMATCH, "ERROR"})
 
+        if m.command == "ERR_PASSWDMISMATCH":
+            m = self.getRegistrationMessage(1)
+            self.assertEqual(
+                m.command, "ERROR", msg="ERR_PASSWDMISMATCH not followed by ERROR."
+            )
+
     @cases.mark_specifications("RFC1459", "RFC2812", strict=True)
     def testPassAfterNickuser(self):
         """“The password can and must be set before any attempt to register

--- a/irctest/server_tests/connection_registration.py
+++ b/irctest/server_tests/connection_registration.py
@@ -36,8 +36,14 @@ class PasswordedConnectionRegistrationTestCase(cases.BaseServerTestCase):
             m.command, "001", msg="Got 001 after NICK+USER but missing PASS"
         )
 
-    @cases.mark_specifications("RFC1459", "RFC2812")
+    @cases.mark_specifications("Modern")
     def testWrongPassword(self):
+        """
+        "If the password supplied does not match the password expected by the server,
+        then the server SHOULD send ERR_PASSWDMISMATCH and MUST close the connection
+        with ERROR."
+        -- https://github.com/ircdocs/modern-irc/pull/172
+        """
         self.addClient()
         self.sendLine(1, "PASS {}".format(self.password + "garbage"))
         self.sendLine(1, "NICK foo")


### PR DESCRIPTION
At least Solanum and Ergo use ERR_PASSWDMISMATCH, and at least
Unreal and Insp use ERROR.