### PR TITLE
fix processing of multiline CAP LS 302 output

### DIFF
--- a/irctest/cases.py
+++ b/irctest/cases.py
@@ -672,7 +672,7 @@ class BaseServerTestCase(
         client = self.addClient(name, show_io=show_io)
         if capabilities:
             self.sendLine(client, "CAP LS 302")
-            m = self.getRegistrationMessage(client)
+            self.getCapLs(client)
             self.requestCapabilities(client, capabilities, skip_if_cap_nak)
         if password is not None:
             if "sasl" not in (capabilities or ()):


### PR DESCRIPTION
connectClient implicitly assumed that the CAP LS 302 output would be
a single registration message. This caused incorrect skipping of some tests
with `skip_if_cap_nak=True`, for example
RegisterEmailVerifiedTestCase.testAfterConnect on Ergo.

Technically there is no need for connectClient to send CAP LS before CAP REQ;
however, this provides additional test coverage for the syntactic correctness
of the CAP LS output in multiple server configurations, so we might as well
keep it.