### PR TITLE
Bump Unreal to 6.0.3 and remove ELIST workarounds

### DIFF
--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -342,7 +342,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: unrealircd
-        ref: daa0c11f285c7123ba9fa2966dee2d1a17729f1e
+        ref: cedd23ae9cdd5985ce16e9869cbdb808479c3fc4
         repository: unrealircd/unrealircd
     - name: Build UnrealIRCd 6
       run: |

--- a/irctest/controllers/unrealircd.py
+++ b/irctest/controllers/unrealircd.py
@@ -139,6 +139,7 @@ class UnrealircdController(BaseServerController, DirectoryBasedController):
     supports_sts = False
 
     extban_mute_char = "quiet" if installed_version() >= 6 else "q"
+    software_version = installed_version()
 
     def create_config(self) -> None:
         super().create_config()

--- a/workflows.yml
+++ b/workflows.yml
@@ -267,8 +267,8 @@ software:
         name: UnrealIRCd 6
         repository: unrealircd/unrealircd
         refs:
-            stable: daa0c11f285c7123ba9fa2966dee2d1a17729f1e  # 6.0.2 + a few commits
-            release: 29fd2e772a6b4b9107daa4e3c237df454b055810  # 6.0.2
+            stable: cedd23ae9cdd5985ce16e9869cbdb808479c3fc4  # 6.0.3
+            release: cedd23ae9cdd5985ce16e9869cbdb808479c3fc4  # 6.0.3
             devel: unreal60_dev
             devel_release: null
         path: unrealircd


### PR DESCRIPTION
And remove workarounds that are only still needed for Unreal 5 and and Hybrid/Plexus