### PR TITLE
update bot tag name to ratified version

### DIFF
--- a/irctest/server_tests/bot_mode.py
+++ b/irctest/server_tests/bot_mode.py
@@ -85,7 +85,7 @@ class BotModeTestCase(cases.BaseServerTestCase):
             self.getMessage("user"),
             command="PRIVMSG",
             params=["usernick", "beep boop"],
-            tags={"draft/bot": None, **ANYDICT},
+            tags={"bot": None, **ANYDICT},
         )
 
     @cases.xfailIfSoftware(
@@ -111,7 +111,7 @@ class BotModeTestCase(cases.BaseServerTestCase):
             self.getMessage("user"),
             command="PRIVMSG",
             params=["#chan", "beep boop"],
-            tags={"draft/bot": None, **ANYDICT},
+            tags={"bot": None, **ANYDICT},
         )
 
     def testBotWhox(self):


### PR DESCRIPTION
Not sure there is a graceful way to merge this without temporarily breaking the build. Ergo's master branch is updated to send the unprefixed `bot` tag, but the `irctest_stable` branch is not.