### PR TITLE
Added dirty fix for race condition in getMessage()

### DIFF
--- a/irctest/client_mock.py
+++ b/irctest/client_mock.py
@@ -120,6 +120,7 @@ class ClientMock:
         __tracebackhide__ = True  # Hide from pytest tracebacks on test failure.
         while True:
             if not self.inbuffer:
+                time.sleep(0.01)
                 self.inbuffer = self.getMessages(
                     synchronize=synchronize, assert_get_one=True, raw=raw
                 )


### PR DESCRIPTION
In the current implementation, there is a race condition between irctest and the tested controller/server such that if the IRC server socket doesn't send a response fast enough, or if `ClientMock.getMessage()` reads from the socket too early, it will raise a NoMessageException.

This may cause tests to yield inconsistent results. Sometimes they may pass, and in other instances they may fail.

Upon inspecting `getMessage()`, I see that the following condition is checked twice successively: `if not self.inbuffer:`
and if this condition is True on the second check, NoMessageException is raised.

The IRC server being tested may send a response every time, but if this function reads a little early (the difference could be 0.00001s), then `if not self.inbuffer:` will be True.

To reduce the likelihood of this happening, I have added a dirty quick fix which provides a remedy to the solution.
I added a call to `time.sleep(0.01)` after the first `if not self.inbuffer:` to give the IRC server a little extra time to send the respond.

However, ideally this issue would be solved by either:
- Adding a retry mechanism which retries up to n times, and sleeps for a small duration in between each retry
- Wait until a response is received with a timeout

I haven't implemented this as to leave the liberty of choosing how to address this to the repo owner.

All the best, and thank you for this very handy test suite!