### PR TITLE
Run utf8 tests on servers which advertise UTF8ONLY

### DIFF
--- a/irctest/specifications.py
+++ b/irctest/specifications.py
@@ -56,6 +56,7 @@ class IsupportTokens(enum.Enum):
     MONITOR = "MONITOR"
     STATUSMSG = "STATUSMSG"
     TARGMAX = "TARGMAX"
+    UTF8ONLY = "UTF8ONLY"
     WHOX = "WHOX"
 
     @classmethod

--- a/pytest.ini
+++ b/pytest.ini
@@ -38,6 +38,7 @@ markers =
     PREFIX
     STATUSMSG
     TARGMAX
+    UTF8ONLY
     WHOX
 
 python_classes = *TestCase Test*


### PR DESCRIPTION
Also allow WARN and ERROR as responses to non-utf8 input.