### PR TITLE
ci: Bump versions of actions we use

### DIFF
--- a/.github/workflows/test-devel.yml
+++ b/.github/workflows/test-devel.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-anope-devel
         path: '~/.cache
@@ -16,13 +16,13 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout Anope
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: anope
         ref: 2.0.9
@@ -37,7 +37,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-anope.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-anope
         path: ~/artefacts-*.tar.gz
@@ -48,7 +48,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-bahamut-devel
         path: '~/.cache
@@ -56,13 +56,13 @@ jobs:
           ${ github.workspace }/Bahamut
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout Bahamut
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: Bahamut
         ref: master
@@ -86,7 +86,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-bahamut.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-bahamut
         path: ~/artefacts-*.tar.gz
@@ -97,7 +97,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-hybrid-devel
         path: '~/.cache
@@ -105,13 +105,13 @@ jobs:
           ${ github.workspace }/ircd-hybrid
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout Hybrid
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ircd-hybrid
         ref: 8.2.x
@@ -125,7 +125,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-hybrid.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-hybrid
         path: ~/artefacts-*.tar.gz
@@ -135,13 +135,13 @@ jobs:
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout InspIRCd
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: inspircd
         ref: master
@@ -156,7 +156,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-inspircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-inspircd
         path: ~/artefacts-*.tar.gz
@@ -167,7 +167,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-ngircd-devel
         path: '~/.cache
@@ -175,13 +175,13 @@ jobs:
           ${ github.workspace }/ngircd
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout ngircd
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ngircd
         ref: master
@@ -197,7 +197,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-ngircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-ngircd
         path: ~/artefacts-*.tar.gz
@@ -208,7 +208,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-plexus4-devel
         path: '~/.cache
@@ -216,9 +216,9 @@ jobs:
           ${ github.workspace }/placeholder
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: clone
@@ -239,7 +239,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-plexus4.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-plexus4
         path: ~/artefacts-*.tar.gz
@@ -250,7 +250,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-solanum-devel
         path: '~/.cache
@@ -258,13 +258,13 @@ jobs:
           ${ github.workspace }/solanum
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout Solanum
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: solanum
         ref: main
@@ -279,7 +279,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-solanum.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-solanum
         path: ~/artefacts-*.tar.gz
@@ -290,7 +290,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-unrealircd-devel
         path: '~/.cache
@@ -298,13 +298,13 @@ jobs:
           ${ github.workspace }/unrealircd
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout UnrealIRCd 6
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: unrealircd
         ref: unreal60_dev
@@ -325,7 +325,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-unrealircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-unrealircd
         path: ~/artefacts-*.tar.gz
@@ -336,7 +336,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-unrealircd-5-devel
         path: '~/.cache
@@ -344,13 +344,13 @@ jobs:
           ${ github.workspace }/unrealircd
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout UnrealIRCd 5
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: unrealircd
         ref: unreal52
@@ -371,7 +371,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-unrealircd-5.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-unrealircd-5
         path: ~/artefacts-*.tar.gz
@@ -403,9 +403,9 @@ jobs:
     - test-unrealircd-dlk
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         path: artifacts
     - name: Install dashboard dependencies
@@ -430,13 +430,13 @@ jobs:
     - build-bahamut
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-bahamut
         path: '~'
@@ -454,7 +454,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_bahamut_devel
         path: pytest.xml
@@ -464,18 +464,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-bahamut
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -493,7 +493,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_bahamut-anope_devel
         path: pytest.xml
@@ -502,13 +502,13 @@ jobs:
     - build-bahamut
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-bahamut
         path: '~'
@@ -526,7 +526,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_bahamut-atheme_devel
         path: pytest.xml
@@ -534,13 +534,13 @@ jobs:
     needs: []
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout Ergo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ergo
         ref: master
@@ -566,7 +566,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_ergo_devel
         path: pytest.xml
@@ -576,18 +576,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-hybrid
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -605,7 +605,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_hybrid_devel
         path: pytest.xml
@@ -614,13 +614,13 @@ jobs:
     - build-inspircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-inspircd
         path: '~'
@@ -638,7 +638,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_inspircd_devel
         path: pytest.xml
@@ -648,18 +648,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-inspircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -677,7 +677,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_inspircd-anope_devel
         path: pytest.xml
@@ -685,13 +685,13 @@ jobs:
     needs: []
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout ircu2
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ircu2
         ref: u2_10_12_branch
@@ -716,7 +716,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_ircu2_devel
         path: pytest.xml
@@ -724,9 +724,9 @@ jobs:
     needs: []
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install dependencies
@@ -744,7 +744,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_limnoria_devel
         path: pytest.xml
@@ -752,13 +752,13 @@ jobs:
     needs: []
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout nefarious
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: nefarious
         ref: master
@@ -782,7 +782,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_nefarious_devel
         path: pytest.xml
@@ -791,13 +791,13 @@ jobs:
     - build-ngircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-ngircd
         path: '~'
@@ -815,7 +815,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_ngircd_devel
         path: pytest.xml
@@ -825,18 +825,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-ngircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -854,7 +854,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_ngircd-anope_devel
         path: pytest.xml
@@ -863,13 +863,13 @@ jobs:
     - build-ngircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-ngircd
         path: '~'
@@ -887,7 +887,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_ngircd-atheme_devel
         path: pytest.xml
@@ -897,18 +897,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-plexus4
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -926,7 +926,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_plexus4_devel
         path: pytest.xml
@@ -935,13 +935,13 @@ jobs:
     - build-solanum
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-solanum
         path: '~'
@@ -959,7 +959,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_solanum_devel
         path: pytest.xml
@@ -967,9 +967,9 @@ jobs:
     needs: []
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install dependencies
@@ -986,7 +986,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_sopel_devel
         path: pytest.xml
@@ -995,13 +995,13 @@ jobs:
     - build-unrealircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-unrealircd
         path: '~'
@@ -1019,7 +1019,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_unrealircd_devel
         path: pytest.xml
@@ -1028,13 +1028,13 @@ jobs:
     - build-unrealircd-5
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-unrealircd-5
         path: '~'
@@ -1052,7 +1052,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_unrealircd-5_devel
         path: pytest.xml
@@ -1062,18 +1062,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-unrealircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -1091,7 +1091,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_unrealircd-anope_devel
         path: pytest.xml
@@ -1100,13 +1100,13 @@ jobs:
     - build-unrealircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-unrealircd
         path: '~'
@@ -1124,7 +1124,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_unrealircd-atheme_devel
         path: pytest.xml
@@ -1133,20 +1133,20 @@ jobs:
     - build-unrealircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-unrealircd
         path: '~'
     - name: Unpack artefacts
       run: cd ~; find -name 'artefacts-*.tar.gz' -exec tar -xzf '{}' \;
     - name: Checkout Dlk
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: Dlk-Services
         ref: main
@@ -1170,7 +1170,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_unrealircd-dlk_devel
         path: pytest.xml

--- a/.github/workflows/test-devel_release.yml
+++ b/.github/workflows/test-devel_release.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-anope-devel_release
         path: '~/.cache
@@ -16,13 +16,13 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout Anope
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: anope
         ref: 2.0.9
@@ -37,7 +37,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-anope.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-anope
         path: ~/artefacts-*.tar.gz
@@ -47,13 +47,13 @@ jobs:
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout InspIRCd
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: inspircd
         ref: insp3
@@ -68,7 +68,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-inspircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-inspircd
         path: ~/artefacts-*.tar.gz
@@ -82,9 +82,9 @@ jobs:
     - test-inspircd-atheme
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         path: artifacts
     - name: Install dashboard dependencies
@@ -109,13 +109,13 @@ jobs:
     - build-inspircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-inspircd
         path: '~'
@@ -133,7 +133,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_inspircd_devel_release
         path: pytest.xml
@@ -143,18 +143,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-inspircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -172,7 +172,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_inspircd-anope_devel_release
         path: pytest.xml
@@ -181,13 +181,13 @@ jobs:
     - build-inspircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-inspircd
         path: '~'
@@ -205,7 +205,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_inspircd-atheme_devel_release
         path: pytest.xml

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-anope-stable
         path: '~/.cache
@@ -16,13 +16,13 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout Anope
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: anope
         ref: 2.0.9
@@ -37,7 +37,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-anope.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-anope
         path: ~/artefacts-*.tar.gz
@@ -48,7 +48,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-bahamut-stable
         path: '~/.cache
@@ -56,13 +56,13 @@ jobs:
           ${ github.workspace }/Bahamut
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout Bahamut
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: Bahamut
         ref: v2.2.1
@@ -86,7 +86,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-bahamut.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-bahamut
         path: ~/artefacts-*.tar.gz
@@ -97,7 +97,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-charybdis-stable
         path: '~/.cache
@@ -105,13 +105,13 @@ jobs:
           ${ github.workspace }/charybdis
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout Charybdis
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: charybdis
         ref: charybdis-4.1.2
@@ -126,7 +126,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-charybdis.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-charybdis
         path: ~/artefacts-*.tar.gz
@@ -137,7 +137,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-hybrid-stable
         path: '~/.cache
@@ -145,13 +145,13 @@ jobs:
           ${ github.workspace }/ircd-hybrid
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout Hybrid
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ircd-hybrid
         ref: 8.2.39
@@ -165,7 +165,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-hybrid.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-hybrid
         path: ~/artefacts-*.tar.gz
@@ -175,13 +175,13 @@ jobs:
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout InspIRCd
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: inspircd
         ref: v3.15.0
@@ -196,7 +196,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-inspircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-inspircd
         path: ~/artefacts-*.tar.gz
@@ -207,7 +207,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-ngircd-stable
         path: '~/.cache
@@ -215,13 +215,13 @@ jobs:
           ${ github.workspace }/ngircd
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout ngircd
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ngircd
         ref: rel-26.1
@@ -237,7 +237,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-ngircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-ngircd
         path: ~/artefacts-*.tar.gz
@@ -248,7 +248,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-plexus4-stable
         path: '~/.cache
@@ -256,9 +256,9 @@ jobs:
           ${ github.workspace }/placeholder
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: clone
@@ -279,7 +279,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-plexus4.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-plexus4
         path: ~/artefacts-*.tar.gz
@@ -290,7 +290,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-solanum-stable
         path: '~/.cache
@@ -298,13 +298,13 @@ jobs:
           ${ github.workspace }/solanum
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout Solanum
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: solanum
         ref: 492d560ee13e71dc35403fd676e58c2d5bdcf2a9
@@ -319,7 +319,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-solanum.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-solanum
         path: ~/artefacts-*.tar.gz
@@ -330,7 +330,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-unrealircd-stable
         path: '~/.cache
@@ -338,13 +338,13 @@ jobs:
           ${ github.workspace }/unrealircd
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout UnrealIRCd 6
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: unrealircd
         ref: da3c1c654481a33035b9c703957e1c25d0158259
@@ -365,7 +365,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-unrealircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-unrealircd
         path: ~/artefacts-*.tar.gz
@@ -376,7 +376,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: 3-${{ runner.os }}-unrealircd-5-stable
         path: '~/.cache
@@ -384,13 +384,13 @@ jobs:
           ${ github.workspace }/unrealircd
 
           '
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout UnrealIRCd 5
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: unrealircd
         ref: 6604856973f713a494f83d38992d7d61ce6b9db4
@@ -411,7 +411,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-unrealircd-5.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: installed-unrealircd-5
         path: ~/artefacts-*.tar.gz
@@ -446,9 +446,9 @@ jobs:
     - test-unrealircd-dlk
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         path: artifacts
     - name: Install dashboard dependencies
@@ -473,13 +473,13 @@ jobs:
     - build-bahamut
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-bahamut
         path: '~'
@@ -497,7 +497,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_bahamut_stable
         path: pytest.xml
@@ -507,18 +507,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-bahamut
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -536,7 +536,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_bahamut-anope_stable
         path: pytest.xml
@@ -545,13 +545,13 @@ jobs:
     - build-bahamut
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-bahamut
         path: '~'
@@ -569,7 +569,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_bahamut-atheme_stable
         path: pytest.xml
@@ -578,13 +578,13 @@ jobs:
     - build-charybdis
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-charybdis
         path: '~'
@@ -602,7 +602,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_charybdis_stable
         path: pytest.xml
@@ -610,13 +610,13 @@ jobs:
     needs: []
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout Ergo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ergo
         ref: irctest_stable
@@ -642,7 +642,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_ergo_stable
         path: pytest.xml
@@ -652,18 +652,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-hybrid
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -681,7 +681,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_hybrid_stable
         path: pytest.xml
@@ -690,13 +690,13 @@ jobs:
     - build-inspircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-inspircd
         path: '~'
@@ -714,7 +714,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_inspircd_stable
         path: pytest.xml
@@ -724,18 +724,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-inspircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -753,7 +753,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_inspircd-anope_stable
         path: pytest.xml
@@ -762,13 +762,13 @@ jobs:
     - build-inspircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-inspircd
         path: '~'
@@ -786,7 +786,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_inspircd-atheme_stable
         path: pytest.xml
@@ -794,13 +794,13 @@ jobs:
     needs: []
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout irc2
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: irc2.11.2p3
         ref: 59649f24c3a5c27bad5648b48774f27475bccfd3
@@ -836,7 +836,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_irc2_stable
         path: pytest.xml
@@ -844,13 +844,13 @@ jobs:
     needs: []
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout ircu2
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ircu2
         ref: u2.10.12.19
@@ -875,7 +875,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_ircu2_stable
         path: pytest.xml
@@ -883,9 +883,9 @@ jobs:
     needs: []
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install dependencies
@@ -902,7 +902,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_limnoria_stable
         path: pytest.xml
@@ -910,13 +910,13 @@ jobs:
     needs: []
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Checkout nefarious
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: nefarious
         ref: 985704168ecada12d9e53b46df6087ef9d9fb40b
@@ -940,7 +940,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_nefarious_stable
         path: pytest.xml
@@ -949,13 +949,13 @@ jobs:
     - build-ngircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-ngircd
         path: '~'
@@ -973,7 +973,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_ngircd_stable
         path: pytest.xml
@@ -983,18 +983,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-ngircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -1012,7 +1012,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_ngircd-anope_stable
         path: pytest.xml
@@ -1021,13 +1021,13 @@ jobs:
     - build-ngircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-ngircd
         path: '~'
@@ -1045,7 +1045,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_ngircd-atheme_stable
         path: pytest.xml
@@ -1055,18 +1055,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-plexus4
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -1084,7 +1084,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_plexus4_stable
         path: pytest.xml
@@ -1093,13 +1093,13 @@ jobs:
     - build-solanum
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-solanum
         path: '~'
@@ -1117,7 +1117,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_solanum_stable
         path: pytest.xml
@@ -1125,9 +1125,9 @@ jobs:
     needs: []
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install dependencies
@@ -1144,7 +1144,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_sopel_stable
         path: pytest.xml
@@ -1153,13 +1153,13 @@ jobs:
     - build-unrealircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-unrealircd
         path: '~'
@@ -1177,7 +1177,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_unrealircd_stable
         path: pytest.xml
@@ -1186,13 +1186,13 @@ jobs:
     - build-unrealircd-5
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-unrealircd-5
         path: '~'
@@ -1210,7 +1210,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_unrealircd-5_stable
         path: pytest.xml
@@ -1220,18 +1220,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-unrealircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-anope
         path: '~'
@@ -1249,7 +1249,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_unrealircd-anope_stable
         path: pytest.xml
@@ -1258,13 +1258,13 @@ jobs:
     - build-unrealircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-unrealircd
         path: '~'
@@ -1282,7 +1282,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_unrealircd-atheme_stable
         path: pytest.xml
@@ -1291,20 +1291,20 @@ jobs:
     - build-unrealircd
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Download build artefacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: installed-unrealircd
         path: '~'
     - name: Unpack artefacts
       run: cd ~; find -name 'artefacts-*.tar.gz' -exec tar -xzf '{}' \;
     - name: Checkout Dlk
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: Dlk-Services
         ref: effd18652fc1c847d1959089d9cca9ff9837a8c0
@@ -1328,7 +1328,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-results_unrealircd-dlk_stable
         path: pytest.xml

--- a/make_workflows.py
+++ b/make_workflows.py
@@ -65,7 +65,7 @@ def get_install_steps(*, software_config, software_id, version_flavor):
         install_steps = [
             {
                 "name": f"Checkout {name}",
-                "uses": "actions/checkout@v2",
+                "uses": "actions/checkout@v3",
                 "with": {
                     "repository": software_config["repository"],
                     "ref": ref,
@@ -94,7 +94,7 @@ def get_build_job(*, software_config, software_id, version_flavor):
         cache = [
             {
                 "name": "Cache dependencies",
-                "uses": "actions/cache@v2",
+                "uses": "actions/cache@v3",
                 "with": {
                     "path": f"~/.cache\n${{ github.workspace }}/{path}\n",
                     "key": "3-${{ runner.os }}-"
@@ -123,10 +123,10 @@ def get_build_job(*, software_config, software_id, version_flavor):
                 "run": "cd ~/; mkdir -p .local/ go/",
             },
             *cache,
-            {"uses": "actions/checkout@v2"},
+            {"uses": "actions/checkout@v3"},
             {
                 "name": "Set up Python 3.7",
-                "uses": "actions/setup-python@v2",
+                "uses": "actions/setup-python@v4",
                 "with": {"python-version": 3.7},
             },
             *install_steps,
@@ -159,7 +159,7 @@ def get_test_job(*, config, test_config, test_id, version_flavor, jobs):
             downloads.append(
                 {
                     "name": "Download build artefacts",
-                    "uses": "actions/download-artifact@v2",
+                    "uses": "actions/download-artifact@v3",
                     "with": {"name": f"installed-{software_id}", "path": "~"},
                 }
             )
@@ -194,10 +194,10 @@ def get_test_job(*, config, test_config, test_id, version_flavor, jobs):
         "runs-on": "ubuntu-20.04",
         "needs": needs,
         "steps": [
-            {"uses": "actions/checkout@v2"},
+            {"uses": "actions/checkout@v3"},
             {
                 "name": "Set up Python 3.7",
-                "uses": "actions/setup-python@v2",
+                "uses": "actions/setup-python@v4",
                 "with": {"python-version": 3.7},
             },
             *downloads,
@@ -231,7 +231,7 @@ def get_test_job(*, config, test_config, test_id, version_flavor, jobs):
             {
                 "name": "Publish results",
                 "if": "always()",
-                "uses": "actions/upload-artifact@v2",
+                "uses": "actions/upload-artifact@v3",
                 "with": {
                     "name": f"pytest-results_{test_id}_{version_flavor.value}",
                     "path": "pytest.xml",
@@ -250,7 +250,7 @@ def upload_steps(software_id):
         },
         {
             "name": "Upload build artefacts",
-            "uses": "actions/upload-artifact@v2",
+            "uses": "actions/upload-artifact@v3",
             "with": {
                 "name": f"installed-{software_id}",
                 "path": "~/artefacts-*.tar.gz",
@@ -311,10 +311,10 @@ def generate_workflow(config: dict, version_flavor: VersionFlavor):
         # this job then
         "if": "success() || failure()",
         "steps": [
-            {"uses": "actions/checkout@v2"},
+            {"uses": "actions/checkout@v3"},
             {
                 "name": "Download Artifacts",
-                "uses": "actions/download-artifact@v2",
+                "uses": "actions/download-artifact@v3",
                 "with": {"path": "artifacts"},
             },
             {


### PR DESCRIPTION
So Github stops complaining about the deprecated Nodejs version