### PR TITLE
Update CI to run on Ubuntu 22.04.

### DIFF
--- a/.github/workflows/test-devel.yml
+++ b/.github/workflows/test-devel.yml
@@ -72,6 +72,7 @@ jobs:
         cd $GITHUB_WORKSPACE/Bahamut/
         patch src/s_user.c < $GITHUB_WORKSPACE/patches/bahamut_localhost.patch
         patch src/s_bsd.c < $GITHUB_WORKSPACE/patches/bahamut_mainloop.patch
+        patch -p1 < $GITHUB_WORKSPACE/patches/bahamut_ubuntu22.patch
         echo "#undef THROTTLE_ENABLE" >> include/config.h
         libtoolize --force
         aclocal

--- a/.github/workflows/test-devel.yml
+++ b/.github/workflows/test-devel.yml
@@ -3,7 +3,7 @@
 
 jobs:
   build-anope:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -43,7 +43,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-bahamut:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -92,7 +92,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-hybrid:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -131,7 +131,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-inspircd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -166,7 +166,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-ngircd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -207,7 +207,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-plexus4:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -249,7 +249,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-solanum:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -289,7 +289,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-unrealircd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -335,7 +335,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-unrealircd-5:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -406,7 +406,7 @@ jobs:
     - test-unrealircd-anope
     - test-unrealircd-atheme
     - test-unrealircd-dlk
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Download Artifacts
@@ -433,7 +433,7 @@ jobs:
   test-bahamut:
     needs:
     - build-bahamut
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -467,7 +467,7 @@ jobs:
     needs:
     - build-bahamut
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -505,7 +505,7 @@ jobs:
   test-bahamut-atheme:
     needs:
     - build-bahamut
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -537,7 +537,7 @@ jobs:
         path: pytest.xml
   test-ergo:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -579,7 +579,7 @@ jobs:
     needs:
     - build-hybrid
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -617,7 +617,7 @@ jobs:
   test-inspircd:
     needs:
     - build-inspircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -651,7 +651,7 @@ jobs:
     needs:
     - build-inspircd
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -688,7 +688,7 @@ jobs:
         path: pytest.xml
   test-ircu2:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -727,7 +727,7 @@ jobs:
         path: pytest.xml
   test-limnoria:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -755,7 +755,7 @@ jobs:
         path: pytest.xml
   test-nefarious:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -794,7 +794,7 @@ jobs:
   test-ngircd:
     needs:
     - build-ngircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -828,7 +828,7 @@ jobs:
     needs:
     - build-ngircd
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -866,7 +866,7 @@ jobs:
   test-ngircd-atheme:
     needs:
     - build-ngircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -900,7 +900,7 @@ jobs:
     needs:
     - build-plexus4
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -938,7 +938,7 @@ jobs:
   test-solanum:
     needs:
     - build-solanum
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -970,7 +970,7 @@ jobs:
         path: pytest.xml
   test-sopel:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -997,7 +997,7 @@ jobs:
         path: pytest.xml
   test-thelounge:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1036,7 +1036,7 @@ jobs:
   test-unrealircd:
     needs:
     - build-unrealircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1069,7 +1069,7 @@ jobs:
   test-unrealircd-5:
     needs:
     - build-unrealircd-5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1103,7 +1103,7 @@ jobs:
     needs:
     - build-unrealircd
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1141,7 +1141,7 @@ jobs:
   test-unrealircd-atheme:
     needs:
     - build-unrealircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1174,7 +1174,7 @@ jobs:
   test-unrealircd-dlk:
     needs:
     - build-unrealircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7

--- a/.github/workflows/test-devel_release.yml
+++ b/.github/workflows/test-devel_release.yml
@@ -3,7 +3,7 @@
 
 jobs:
   build-anope:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -43,7 +43,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-inspircd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -84,7 +84,7 @@ jobs:
     - test-inspircd
     - test-inspircd-anope
     - test-inspircd-atheme
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Download Artifacts
@@ -111,7 +111,7 @@ jobs:
   test-inspircd:
     needs:
     - build-inspircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -145,7 +145,7 @@ jobs:
     needs:
     - build-inspircd
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -183,7 +183,7 @@ jobs:
   test-inspircd-atheme:
     needs:
     - build-inspircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -72,6 +72,7 @@ jobs:
         cd $GITHUB_WORKSPACE/Bahamut/
         patch src/s_user.c < $GITHUB_WORKSPACE/patches/bahamut_localhost.patch
         patch src/s_bsd.c < $GITHUB_WORKSPACE/patches/bahamut_mainloop.patch
+        patch -p1 < $GITHUB_WORKSPACE/patches/bahamut_ubuntu22.patch
         echo "#undef THROTTLE_ENABLE" >> include/config.h
         libtoolize --force
         aclocal

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -120,6 +120,7 @@ jobs:
     - name: Build Charybdis
       run: |
         cd $GITHUB_WORKSPACE/charybdis/
+        patch -p1 < $GITHUB_WORKSPACE/patches/charybdis_ubuntu22.patch
         ./autogen.sh
         ./configure --prefix=$HOME/.local/
         make -j 4

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -3,7 +3,7 @@
 
 jobs:
   build-anope:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -43,7 +43,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-bahamut:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -92,7 +92,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-charybdis:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -132,7 +132,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-hybrid:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -171,7 +171,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-inspircd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -206,7 +206,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-ngircd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -247,7 +247,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-plexus4:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -289,7 +289,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-solanum:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -329,7 +329,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-unrealircd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -375,7 +375,7 @@ jobs:
         path: ~/artefacts-*.tar.gz
         retention-days: 1
   build-unrealircd-5:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
@@ -449,7 +449,7 @@ jobs:
     - test-unrealircd-anope
     - test-unrealircd-atheme
     - test-unrealircd-dlk
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Download Artifacts
@@ -476,7 +476,7 @@ jobs:
   test-bahamut:
     needs:
     - build-bahamut
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -510,7 +510,7 @@ jobs:
     needs:
     - build-bahamut
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -548,7 +548,7 @@ jobs:
   test-bahamut-atheme:
     needs:
     - build-bahamut
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -581,7 +581,7 @@ jobs:
   test-charybdis:
     needs:
     - build-charybdis
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -613,7 +613,7 @@ jobs:
         path: pytest.xml
   test-ergo:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -655,7 +655,7 @@ jobs:
     needs:
     - build-hybrid
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -693,7 +693,7 @@ jobs:
   test-inspircd:
     needs:
     - build-inspircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -727,7 +727,7 @@ jobs:
     needs:
     - build-inspircd
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -765,7 +765,7 @@ jobs:
   test-inspircd-atheme:
     needs:
     - build-inspircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -797,7 +797,7 @@ jobs:
         path: pytest.xml
   test-irc2:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -847,7 +847,7 @@ jobs:
         path: pytest.xml
   test-ircu2:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -886,7 +886,7 @@ jobs:
         path: pytest.xml
   test-limnoria:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -913,7 +913,7 @@ jobs:
         path: pytest.xml
   test-nefarious:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -952,7 +952,7 @@ jobs:
   test-ngircd:
     needs:
     - build-ngircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -986,7 +986,7 @@ jobs:
     needs:
     - build-ngircd
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1024,7 +1024,7 @@ jobs:
   test-ngircd-atheme:
     needs:
     - build-ngircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1058,7 +1058,7 @@ jobs:
     needs:
     - build-plexus4
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1096,7 +1096,7 @@ jobs:
   test-solanum:
     needs:
     - build-solanum
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1128,7 +1128,7 @@ jobs:
         path: pytest.xml
   test-sopel:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1155,7 +1155,7 @@ jobs:
         path: pytest.xml
   test-thelounge:
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1194,7 +1194,7 @@ jobs:
   test-unrealircd:
     needs:
     - build-unrealircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1227,7 +1227,7 @@ jobs:
   test-unrealircd-5:
     needs:
     - build-unrealircd-5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1261,7 +1261,7 @@ jobs:
     needs:
     - build-unrealircd
     - build-anope
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1299,7 +1299,7 @@ jobs:
   test-unrealircd-atheme:
     needs:
     - build-unrealircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7
@@ -1332,7 +1332,7 @@ jobs:
   test-unrealircd-dlk:
     needs:
     - build-unrealircd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.7

--- a/make_workflows.py
+++ b/make_workflows.py
@@ -116,7 +116,7 @@ def get_build_job(*, software_config, software_id, version_flavor):
         return None
 
     return {
-        "runs-on": "ubuntu-20.04",
+        "runs-on": "ubuntu-22.04",
         "steps": [
             {
                 "name": "Create directories",
@@ -191,7 +191,7 @@ def get_test_job(*, config, test_config, test_id, version_flavor, jobs):
         unpack = []
 
     return {
-        "runs-on": "ubuntu-20.04",
+        "runs-on": "ubuntu-22.04",
         "needs": needs,
         "steps": [
             {"uses": "actions/checkout@v3"},
@@ -306,7 +306,7 @@ def generate_workflow(config: dict, version_flavor: VersionFlavor):
     jobs["publish-test-results"] = {
         "name": "Publish Dashboard",
         "needs": sorted({f"test-{test_id}" for test_id in config["tests"]} & set(jobs)),
-        "runs-on": "ubuntu-20.04",
+        "runs-on": "ubuntu-22.04",
         # the build-and-test job might be skipped, we don't need to run
         # this job then
         "if": "success() || failure()",

--- a/patches/bahamut_ubuntu22.patch
+++ b/patches/bahamut_ubuntu22.patch
@@ -1,0 +1,342 @@
+From 42b67ff7218877934abed2a738e164c0dea171b0 Mon Sep 17 00:00:00 2001
+From: "Ned T. Crigler" <RuneB@dal.net>
+Date: Sun, 26 Feb 2023 17:42:29 -0800
+Subject: [PATCH 1/2] Fix compilation on Ubuntu 22.04
+
+Starting with glibc 2.34 "The symbols __dn_comp, __dn_expand,
+__dn_skipname, __res_dnok, __res_hnok, __res_mailok, __res_mkquery,
+__res_nmkquery, __res_nquery, __res_nquerydomain, __res_nsearch,
+__res_nsend, __res_ownok, __res_query, __res_querydomain, __res_search,
+__res_send formerly in libresolv have been renamed and no longer have a
+__ prefix.  They are now available in libc."
+https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html
+
+The hex_to_string array in include/dh.h also conflicts with OpenSSL,
+which OpenSSL 3.0 now complains about.
+---
+ configure.in     | 4 ++--
+ include/dh.h     | 2 +-
+ include/resolv.h | 6 +++++-
+ src/dh.c         | 2 +-
+ 4 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/configure.in b/configure.in
+index e76dee88..11720419 100644
+--- a/configure.in
++++ b/configure.in
+@@ -374,8 +374,7 @@ AC_C_INLINE
+ dnl Checks for libraries.
+ dnl Replace `main' with a function in -lnsl:
+ AC_CHECK_LIB(nsl, gethostbyname)
+-AC_CHECK_FUNC(res_mkquery,, AC_CHECK_LIB(resolv, res_mkquery))
+-AC_CHECK_FUNC(__res_mkquery,, AC_CHECK_LIB(resolv, __res_mkquery))
++AC_SEARCH_LIBS([res_mkquery],[resolv],,AC_SEARCH_LIBS([__res_mkquery],[resolv]))
+ AC_CHECK_LIB(socket, socket, zlib)
+ AC_CHECK_FUNC(crypt,, AC_CHECK_LIB(descrypt, crypt,,AC_CHECK_LIB(crypt, crypt,,)))
+ 
+@@ -406,6 +405,7 @@ AC_CHECK_FUNCS([strcasecmp strchr strdup strerror strncasecmp strrchr strtol])
+ AC_CHECK_FUNCS([strtoul index strerror strtoken strtok inet_addr inet_netof])
+ AC_CHECK_FUNCS([inet_aton gettimeofday lrand48 sigaction bzero bcmp bcopy])
+ AC_CHECK_FUNCS([dn_skipname __dn_skipname getrusage times break])
++AC_CHECK_FUNCS([res_init __res_init res_mkquery __res_mkquery dn_expand __dn_expand])
+ 
+ dnl check for various OSes
+ 
+diff --git a/include/dh.h b/include/dh.h
+index 1ca6996a..1817ce1e 100644
+--- a/include/dh.h
++++ b/include/dh.h
+@@ -45,7 +45,7 @@ struct session_info
+ static BIGNUM *ircd_prime;
+ static BIGNUM *ircd_generator;
+ 
+-static char *hex_to_string[256] =
++static char *dh_hex_to_string[256] =
+ {
+     "00", "01", "02", "03", "04", "05", "06", "07",
+     "08", "09", "0a", "0b", "0c", "0d", "0e", "0f",
+diff --git a/include/resolv.h b/include/resolv.h
+index b5a8aaa1..5b042d43 100644
+--- a/include/resolv.h
++++ b/include/resolv.h
+@@ -106,9 +106,13 @@ extern struct state _res;
+ 
+ extern char *p_cdname(), *p_rr(), *p_type(), *p_class(), *p_time();
+ 
+-#if ((__GNU_LIBRARY__ == 6) && (__GLIBC__ >=2) && (__GLIBC_MINOR__ >= 2))
++#if !defined(HAVE_RES_INIT) && defined(HAVE___RES_INIT)
+ #define res_init __res_init
++#endif
++#if !defined(HAVE_RES_MKQUERY) && defined(HAVE___RES_MKQUERY)
+ #define res_mkquery __res_mkquery
++#endif
++#if !defined(HAVE_DN_EXPAND) && defined(HAVE___DN_EXPAND)
+ #define dn_expand __dn_expand
+ #endif
+ 
+diff --git a/src/dh.c b/src/dh.c
+index cb065a4f..4b5da282 100644
+--- a/src/dh.c
++++ b/src/dh.c
+@@ -223,7 +223,7 @@ static void create_prime()
+ 
+     for(i = 0; i < PRIME_BYTES; i++)
+     {
+-        char *x = hex_to_string[dh_prime_1024[i]];
++        char *x = dh_hex_to_string[dh_prime_1024[i]];
+         while(*x)
+             buf[bufpos++] = *x++;
+     }
+
+From 135ebbea4c30e23228d00af762fa7da7ca5016bd Mon Sep 17 00:00:00 2001
+From: "Ned T. Crigler" <RuneB@dal.net>
+Date: Mon, 22 May 2023 15:31:54 -0700
+Subject: [PATCH 2/2] Update the dh code to work with OpenSSL 3.0
+
+---
+ include/dh.h |   8 ++++
+ src/dh.c     | 120 ++++++++++++++++++++++++++++++++++++++++++++++++---
+ 2 files changed, 123 insertions(+), 5 deletions(-)
+
+diff --git a/include/dh.h b/include/dh.h
+index 1817ce1e..705e6dee 100644
+--- a/include/dh.h
++++ b/include/dh.h
+@@ -22,7 +22,11 @@ extern void rc4_destroystate(void *a);
+ 
+ struct session_info
+ {
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+     DH *dh;
++#else
++    EVP_PKEY *dh;
++#endif
+     unsigned char *session_shared;
+     size_t session_shared_length;
+ };
+@@ -45,6 +49,10 @@ struct session_info
+ static BIGNUM *ircd_prime;
+ static BIGNUM *ircd_generator;
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++static EVP_PKEY *ircd_prime_ossl3;
++#endif
++
+ static char *dh_hex_to_string[256] =
+ {
+     "00", "01", "02", "03", "04", "05", "06", "07",
+diff --git a/src/dh.c b/src/dh.c
+index 4b5da282..f74d2d76 100644
+--- a/src/dh.c
++++ b/src/dh.c
+@@ -36,6 +36,11 @@
+ #include <openssl/dh.h>
+ #include "libcrypto-compat.h"
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++#include <openssl/core_names.h>
++#include <openssl/param_build.h>
++#endif
++
+ #include "memcount.h"
+ 
+ #define DH_HEADER
+@@ -215,7 +220,7 @@ static int init_random()
+     return 0;
+ }
+ 
+-static void create_prime()
++static int create_prime()
+ {
+     char buf[PRIME_BYTES_HEX];
+     int i;
+@@ -233,6 +238,34 @@ static void create_prime()
+     BN_hex2bn(&ircd_prime, buf);
+     ircd_generator = BN_new();
+     BN_set_word(ircd_generator, dh_gen_1024);
++
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++    OSSL_PARAM_BLD *paramBuild = NULL;
++    OSSL_PARAM *param = NULL;
++    EVP_PKEY_CTX *primeCtx = NULL;
++
++    if(!(paramBuild = OSSL_PARAM_BLD_new()) ||
++       !OSSL_PARAM_BLD_push_BN(paramBuild, OSSL_PKEY_PARAM_FFC_P, ircd_prime) ||
++       !OSSL_PARAM_BLD_push_BN(paramBuild, OSSL_PKEY_PARAM_FFC_G, ircd_generator) ||
++       !(param = OSSL_PARAM_BLD_to_param(paramBuild)) ||
++       !(primeCtx = EVP_PKEY_CTX_new_from_name(NULL, "DHX", NULL)) ||
++       EVP_PKEY_fromdata_init(primeCtx) <= 0 ||
++       EVP_PKEY_fromdata(primeCtx, &ircd_prime_ossl3,
++                         EVP_PKEY_KEY_PARAMETERS, param) <= 0 ||
++       1)
++    {
++        if(primeCtx)
++            EVP_PKEY_CTX_free(primeCtx);
++        if(param)
++            OSSL_PARAM_free(param);
++        if(paramBuild)
++            OSSL_PARAM_BLD_free(paramBuild);
++    }
++
++    if(!ircd_prime_ossl3)
++        return -1;
++#endif
++    return 0;
+ }
+ 
+ int dh_init()
+@@ -241,8 +274,7 @@ int dh_init()
+     ERR_load_crypto_strings();
+ #endif
+ 
+-    create_prime();
+-    if(init_random() == -1)
++    if(create_prime() == -1 || init_random() == -1)
+         return -1;
+     return 0; 
+ }
+@@ -250,7 +282,7 @@ int dh_init()
+ int dh_generate_shared(void *session, char *public_key)
+ {
+     BIGNUM *tmp;
+-    int len;
++    size_t len;
+     struct session_info *si = (struct session_info *) session;
+ 
+     if(verify_is_hex(public_key) == 0 || !si || si->session_shared)
+@@ -261,13 +293,55 @@ int dh_generate_shared(void *session, char *public_key)
+     if(!tmp)
+         return 0;
+ 
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+     si->session_shared_length = DH_size(si->dh);
+     si->session_shared = (unsigned char *) malloc(DH_size(si->dh));
+     len = DH_compute_key(si->session_shared, tmp, si->dh);
++#else
++    OSSL_PARAM_BLD *paramBuild = NULL;
++    OSSL_PARAM *param = NULL;
++    EVP_PKEY_CTX *peerPubKeyCtx = NULL;
++    EVP_PKEY *peerPubKey = NULL;
++    EVP_PKEY_CTX *deriveCtx = NULL;
++
++    len = -1;
++    if(!(paramBuild = OSSL_PARAM_BLD_new()) ||
++       !OSSL_PARAM_BLD_push_BN(paramBuild, OSSL_PKEY_PARAM_FFC_P, ircd_prime) ||
++       !OSSL_PARAM_BLD_push_BN(paramBuild, OSSL_PKEY_PARAM_FFC_G, ircd_generator) ||
++       !OSSL_PARAM_BLD_push_BN(paramBuild, OSSL_PKEY_PARAM_PUB_KEY, tmp) ||
++       !(param = OSSL_PARAM_BLD_to_param(paramBuild)) ||
++       !(peerPubKeyCtx = EVP_PKEY_CTX_new_from_name(NULL, "DHX", NULL)) ||
++       EVP_PKEY_fromdata_init(peerPubKeyCtx) <= 0 ||
++       EVP_PKEY_fromdata(peerPubKeyCtx, &peerPubKey,
++                         EVP_PKEY_PUBLIC_KEY, param) <= 0 ||
++       !(deriveCtx = EVP_PKEY_CTX_new(si->dh, NULL)) ||
++       EVP_PKEY_derive_init(deriveCtx) <= 0 ||
++       EVP_PKEY_derive_set_peer(deriveCtx, peerPubKey) <= 0 ||
++       EVP_PKEY_derive(deriveCtx, NULL, &len) <= 0 ||
++       !(si->session_shared = malloc(len)) ||
++       EVP_PKEY_derive(deriveCtx, si->session_shared, &len) <= 0 ||
++       1)
++    {
++        if(deriveCtx)
++            EVP_PKEY_CTX_free(deriveCtx);
++        if(peerPubKey)
++            EVP_PKEY_free(peerPubKey);
++        if(peerPubKeyCtx)
++            EVP_PKEY_CTX_free(peerPubKeyCtx);
++        if(param)
++            OSSL_PARAM_free(param);
++        if(paramBuild)
++            OSSL_PARAM_BLD_free(paramBuild);
++    }
++#endif
+     BN_free(tmp);
+ 
+-    if(len < 0)
++    if(len == -1 || !si->session_shared)
++    {
++        if(si->session_shared)
++            free(si->session_shared);
+         return 0;
++    }
+ 
+     si->session_shared_length = len;
+ 
+@@ -284,6 +358,7 @@ void *dh_start_session()
+ 
+     memset(si, 0, sizeof(struct session_info));
+ 
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+     si->dh = DH_new();
+ 	if(si->dh == NULL)
+ 		return NULL;
+@@ -304,7 +379,23 @@ void *dh_start_session()
+         MyFree(si);
+         return NULL;
+     }
++#else
++    EVP_PKEY_CTX *keyGenCtx = NULL;
+ 
++    if(!(keyGenCtx = EVP_PKEY_CTX_new_from_pkey(NULL, ircd_prime_ossl3, NULL)) ||
++        EVP_PKEY_keygen_init(keyGenCtx) <= 0 ||
++        EVP_PKEY_generate(keyGenCtx, &si->dh) <= 0 ||
++        1)
++    {
++        if(keyGenCtx)
++            EVP_PKEY_CTX_free(keyGenCtx);
++    }
++    if(!si->dh)
++    {
++        MyFree(si);
++        return NULL;
++    }
++#endif
+     return (void *) si;
+ }
+ 
+@@ -312,6 +403,7 @@ void dh_end_session(void *session)
+ {
+     struct session_info *si = (struct session_info *) session;
+ 
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+     if(si->dh)
+     {
+         DH_free(si->dh);
+@@ -324,6 +416,13 @@ void dh_end_session(void *session)
+         free(si->session_shared);
+         si->session_shared = NULL;
+     }
++#else
++    if(si->dh)
++    {
++        EVP_PKEY_free(si->dh);
++        si->dh = NULL;
++    }
++#endif
+ 
+     MyFree(si);
+ }
+@@ -333,6 +432,7 @@ char *dh_get_s_public(char *buf, size_t maxlen, void *session)
+     struct session_info *si = (struct session_info *) session;
+     char *tmp;
+ 
++#if OPENSSL_VERSION_NUMBER < 0x30000000L
+     if(!si || !si->dh)
+ 		return NULL;
+ 
+@@ -343,6 +443,16 @@ char *dh_get_s_public(char *buf, size_t maxlen, void *session)
+ 		return NULL;
+ 
+ 	tmp = BN_bn2hex(pub_key);
++#else
++    BIGNUM *pub_key = NULL;
++
++    if(!si || !si->dh)
++        return NULL;
++    if(!EVP_PKEY_get_bn_param(si->dh, OSSL_PKEY_PARAM_PUB_KEY, &pub_key))
++        return NULL;
++    tmp = BN_bn2hex(pub_key);
++    BN_free(pub_key);
++#endif
+     if(!tmp)
+         return NULL;
+ 

--- a/patches/charybdis_ubuntu22.patch
+++ b/patches/charybdis_ubuntu22.patch
@@ -1,0 +1,23 @@
+From fa5d445e5e2af735378a1219d2a200ee8aef6561 Mon Sep 17 00:00:00 2001
+From: Sadie Powell <sadie@witchery.services>
+Date: Sun, 25 Jun 2023 21:50:42 +0100
+Subject: [PATCH] Fix Charybdis on Ubuntu 22.04.
+
+---
+ librb/include/rb_lib.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/librb/include/rb_lib.h b/librb/include/rb_lib.h
+index c02dff68..0dd9c378 100644
+--- a/librb/include/rb_lib.h
++++ b/librb/include/rb_lib.h
+@@ -258,4 +258,6 @@ pid_t rb_getpid(void);
+ #include <rb_rawbuf.h>
+ #include <rb_patricia.h>
+ 
++#include <time.h>
++
+ #endif
+-- 
+2.34.1
+

--- a/workflows.yml
+++ b/workflows.yml
@@ -106,6 +106,7 @@ software:
             cd $GITHUB_WORKSPACE/Bahamut/
             patch src/s_user.c < $GITHUB_WORKSPACE/patches/bahamut_localhost.patch
             patch src/s_bsd.c < $GITHUB_WORKSPACE/patches/bahamut_mainloop.patch
+            patch -p1 < $GITHUB_WORKSPACE/patches/bahamut_ubuntu22.patch
             echo "#undef THROTTLE_ENABLE" >> include/config.h
             libtoolize --force
             aclocal

--- a/workflows.yml
+++ b/workflows.yml
@@ -18,6 +18,7 @@ software:
         separate_build_job: true
         build_script: |
             cd $GITHUB_WORKSPACE/charybdis/
+            patch -p1 < $GITHUB_WORKSPACE/patches/charybdis_ubuntu22.patch
             ./autogen.sh
             ./configure --prefix=$HOME/.local/
             make -j 4


### PR DESCRIPTION
This is a prerequisite for using Anope from apt which should speed up running the Anope+InspIRCd job slightly.

This requires two patches to fix the build of Bahamut (patch sourced from an upstream pull request) and Charybdis (as this is very dead is this needed anymore?).