### PR TITLE
test that PART actually parts

### DIFF
--- a/irctest/server_tests/part.py
+++ b/irctest/server_tests/part.py
@@ -110,7 +110,7 @@ class PartTestCase(cases.BaseServerTestCase):
         for reply in self.getMessages(2):
             if reply.command != RPL_NAMREPLY:
                 continue
-            names.update(reply.params[-1].split())
+            names.update(reply.params[-1].replace("@", "").split())
         self.assertNotIn("bar", names)
         self.assertIn("baz", names)
 


### PR DESCRIPTION
From discussion in #ergo today, I realized that our PART test don't verify that PART actually removes you from the channel.