### PR TITLE
Make AWAY and away-notify tests stricter

### DIFF
--- a/irctest/server_tests/away.py
+++ b/irctest/server_tests/away.py
@@ -50,16 +50,14 @@ class AwayTestCase(cases.BaseServerTestCase):
         self.connectClient("bar")
         self.sendLine(1, "AWAY :I'm not here right now")
         self.assertMessageMatch(
-                self.getMessage(1),
-                command=RPL_NOWAWAY,
-                params=["bar", ANYSTR])
+            self.getMessage(1), command=RPL_NOWAWAY, params=["bar", ANYSTR]
+        )
         self.assertEqual(self.getMessages(1), [])
 
         self.sendLine(1, "AWAY")
         self.assertMessageMatch(
-                self.getMessage(1),
-                command=RPL_UNAWAY,
-                params=["bar", ANYSTR])
+            self.getMessage(1), command=RPL_UNAWAY, params=["bar", ANYSTR]
+        )
         self.assertEqual(self.getMessages(1), [])
 
     @cases.mark_specifications("Modern")

--- a/irctest/server_tests/away.py
+++ b/irctest/server_tests/away.py
@@ -11,13 +11,14 @@ from irctest.numerics import (
     RPL_USERHOST,
     RPL_WHOISUSER,
 )
-from irctest.patma import StrRe
+from irctest.patma import ANYSTR, StrRe
 
 
 class AwayTestCase(cases.BaseServerTestCase):
     @cases.mark_specifications("RFC2812", "Modern")
     def testAway(self):
         self.connectClient("bar")
+        self.getMessages(1)
         self.sendLine(1, "AWAY :I'm not here right now")
         replies = self.getMessages(1)
         self.assertIn(RPL_NOWAWAY, [msg.command for msg in replies])
@@ -29,6 +30,7 @@ class AwayTestCase(cases.BaseServerTestCase):
             command=RPL_AWAY,
             params=["qux", "bar", "I'm not here right now"],
         )
+        self.getMessages(1)
 
         self.sendLine(1, "AWAY")
         replies = self.getMessages(1)
@@ -47,12 +49,18 @@ class AwayTestCase(cases.BaseServerTestCase):
         """
         self.connectClient("bar")
         self.sendLine(1, "AWAY :I'm not here right now")
-        replies = self.getMessages(1)
-        self.assertIn(RPL_NOWAWAY, [msg.command for msg in replies])
+        self.assertMessageMatch(
+                self.getMessage(1),
+                command=RPL_NOWAWAY,
+                params=["bar", ANYSTR])
+        self.assertEqual(self.getMessages(1), [])
 
         self.sendLine(1, "AWAY")
-        replies = self.getMessages(1)
-        self.assertIn(RPL_UNAWAY, [msg.command for msg in replies])
+        self.assertMessageMatch(
+                self.getMessage(1),
+                command=RPL_UNAWAY,
+                params=["bar", ANYSTR])
+        self.assertEqual(self.getMessages(1), [])
 
     @cases.mark_specifications("Modern")
     def testAwayPrivmsg(self):

--- a/irctest/server_tests/away_notify.py
+++ b/irctest/server_tests/away_notify.py
@@ -3,11 +3,8 @@
 """
 
 from irctest import cases
+from irctest.numerics import RPL_NOWAWAY, RPL_UNAWAY
 from irctest.patma import ANYSTR, StrRe
-from irctest.numerics import (
-    RPL_NOWAWAY,
-    RPL_UNAWAY,
-)
 
 
 class AwayNotifyTestCase(cases.BaseServerTestCase):
@@ -26,23 +23,28 @@ class AwayNotifyTestCase(cases.BaseServerTestCase):
 
         self.sendLine(2, "AWAY :i'm going away")
         self.assertMessageMatch(
-                self.getMessage(2),
-                command=RPL_NOWAWAY,
-                params=["bar", ANYSTR])
+            self.getMessage(2), command=RPL_NOWAWAY, params=["bar", ANYSTR]
+        )
         self.assertEqual(self.getMessages(2), [])
 
         awayNotify = self.getMessage(1)
-        self.assertMessageMatch(awayNotify, prefix=StrRe("bar!.*"), command="AWAY", params=["i'm going away"])
+        self.assertMessageMatch(
+            awayNotify,
+            prefix=StrRe("bar!.*"),
+            command="AWAY",
+            params=["i'm going away"],
+        )
 
         self.sendLine(2, "AWAY")
         self.assertMessageMatch(
-                self.getMessage(2),
-                command=RPL_UNAWAY,
-                params=["bar", ANYSTR])
+            self.getMessage(2), command=RPL_UNAWAY, params=["bar", ANYSTR]
+        )
         self.assertEqual(self.getMessages(2), [])
 
         awayNotify = self.getMessage(1)
-        self.assertMessageMatch(awayNotify, prefix=StrRe("bar!.*"), command="AWAY", params=[])
+        self.assertMessageMatch(
+            awayNotify, prefix=StrRe("bar!.*"), command="AWAY", params=[]
+        )
 
     @cases.mark_capabilities("away-notify")
     def testAwayNotifyOnJoin(self):

--- a/irctest/server_tests/away_notify.py
+++ b/irctest/server_tests/away_notify.py
@@ -62,7 +62,11 @@ class AwayNotifyTestCase(cases.BaseServerTestCase):
         self.getMessages(2)
 
         self.joinChannel(2, "#chan")
-        self.getMessages(2)
+        self.assertNotIn(
+            "AWAY",
+            [m.command for m in self.getMessages(2)],
+            "joining user got their own away status when they joined",
+        )
 
         messages = [msg for msg in self.getMessages(1) if msg.command == "AWAY"]
         self.assertEqual(


### PR DESCRIPTION
In particular, tests for https://github.com/ircv3/ircv3-specifications/pull/531