### PR TITLE
Fix lock on the set of used ports

### DIFF
--- a/irctest/basecontrollers.py
+++ b/irctest/basecontrollers.py
@@ -64,7 +64,7 @@ class _BaseController:
     proc: Optional[subprocess.Popen]
 
     _used_ports_path = Path(tempfile.gettempdir()) / "irctest_ports.json"
-    _port_lock = FileLock( Path(tempfile.gettempdir()) / "irctest_ports.json.lock")
+    _port_lock = FileLock(Path(tempfile.gettempdir()) / "irctest_ports.json.lock")
 
     def __init__(self, test_config: TestCaseControllerConfig):
         self.test_config = test_config

--- a/irctest/basecontrollers.py
+++ b/irctest/basecontrollers.py
@@ -13,12 +13,11 @@ import textwrap
 import time
 from typing import IO, Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Type
 
-from filelock import FileLock
-
 import irctest
 
 from . import authentication, tls
 from .client_mock import ClientMock
+from .irc_utils.filelock import FileLock
 from .irc_utils.junkdrawer import find_hostname_and_port
 from .irc_utils.message_parser import Message
 from .runner import NotImplementedByController

--- a/irctest/basecontrollers.py
+++ b/irctest/basecontrollers.py
@@ -63,8 +63,8 @@ class _BaseController:
 
     proc: Optional[subprocess.Popen]
 
-    _used_ports_path = Path("/tmp/irctest_ports.json")
-    _port_lock = FileLock(f"{_used_ports_path}.lock")
+    _used_ports_path = Path(tempfile.gettempdir()) / "irctest_ports.json"
+    _port_lock = FileLock( Path(tempfile.gettempdir()) / "irctest_ports.json.lock")
 
     def __init__(self, test_config: TestCaseControllerConfig):
         self.test_config = test_config

--- a/irctest/irc_utils/filelock.py
+++ b/irctest/irc_utils/filelock.py
@@ -5,6 +5,7 @@ in some environments.
 """
 
 import os
+from typing import ContextManager
 
 if os.getenv("PYTEST_XDIST_WORKER"):
     # running under pytest-xdist; filelock is required for reliability
@@ -13,5 +14,5 @@ else:
     # normal test execution, no port races
     import contextlib
 
-    def FileLock(*args, **kwargs):
+    def FileLock() -> ContextManager[None]:
         return contextlib.nullcontext()

--- a/irctest/irc_utils/filelock.py
+++ b/irctest/irc_utils/filelock.py
@@ -1,0 +1,19 @@
+"""
+Compatibility layer for filelock ( https://pypi.org/project/filelock/ );
+commonly packaged by Linux distributions but might not be available
+in some environments.
+"""
+
+try:
+    from filelock import FileLock
+except ImportError:
+    import contextlib
+    import warnings
+
+    warnings.warn(
+        "filelock package unavailable, concurrent runs may race",
+        RuntimeWarning,
+    )
+
+    def FileLock(*args, **kwargs):
+        return contextlib.nullcontext()

--- a/irctest/irc_utils/filelock.py
+++ b/irctest/irc_utils/filelock.py
@@ -4,16 +4,14 @@ commonly packaged by Linux distributions but might not be available
 in some environments.
 """
 
-try:
-    from filelock import FileLock
-except ImportError:
-    import contextlib
-    import warnings
+import os
 
-    warnings.warn(
-        "filelock package unavailable, concurrent runs may race",
-        RuntimeWarning,
-    )
+if os.getenv("PYTEST_XDIST_WORKER"):
+    # running under pytest-xdist; filelock is required for reliability
+    from filelock import FileLock
+else:
+    # normal test execution, no port races
+    import contextlib
 
     def FileLock(*args, **kwargs):
         return contextlib.nullcontext()

--- a/irctest/irc_utils/filelock.py
+++ b/irctest/irc_utils/filelock.py
@@ -13,6 +13,7 @@ if os.getenv("PYTEST_XDIST_WORKER"):
 else:
     # normal test execution, no port races
     import contextlib
+    from typing import Any
 
-    def FileLock() -> ContextManager[None]:
+    def FileLock(*args: Any, **kwargs: Any) -> ContextManager[None]:
         return contextlib.nullcontext()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+filelock
+pytest
+
 # The following dependencies are actually optional:
 ecdsa
-pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-filelock
 pytest
 
 # The following dependencies are actually optional:
 ecdsa
+filelock


### PR DESCRIPTION
pytest-xdist (well, execnet) re-loads modules after forking, so each process had its own lock, making the lock useless.