### PR TITLE
make filelock optional

### DIFF
--- a/irctest/basecontrollers.py
+++ b/irctest/basecontrollers.py
@@ -13,12 +13,11 @@ import textwrap
 import time
 from typing import IO, Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Type
 
-from filelock import FileLock
-
 import irctest
 
 from . import authentication, tls
 from .client_mock import ClientMock
+from .irc_utils.filelock import FileLock
 from .irc_utils.junkdrawer import find_hostname_and_port
 from .irc_utils.message_parser import Message
 from .runner import NotImplementedByController

--- a/irctest/irc_utils/filelock.py
+++ b/irctest/irc_utils/filelock.py
@@ -1,0 +1,19 @@
+"""
+Compatibility layer for filelock ( https://pypi.org/project/filelock/ );
+commonly packaged by Linux distributions but might not be available
+in some environments.
+"""
+
+try:
+    from filelock import FileLock
+except ImportError:
+    import contextlib
+    import warnings
+
+    warnings.warn(
+        "filelock package unavailable, concurrent runs may race",
+        RuntimeWarning,
+    )
+
+    def FileLock(*args, **kwargs):
+        return contextlib.nullcontext()

--- a/irctest/irc_utils/filelock.py
+++ b/irctest/irc_utils/filelock.py
@@ -4,16 +4,14 @@ commonly packaged by Linux distributions but might not be available
 in some environments.
 """
 
-try:
-    from filelock import FileLock
-except ImportError:
-    import contextlib
-    import warnings
+import os
 
-    warnings.warn(
-        "filelock package unavailable, concurrent runs may race",
-        RuntimeWarning,
-    )
+if os.getenv("PYTEST_XDIST_WORKER"):
+    # running under pytest-xdist; filelock is required for reliability
+    from filelock import FileLock
+else:
+    # normal test execution, no port races
+    import contextlib
 
     def FileLock(*args, **kwargs):
         return contextlib.nullcontext()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-filelock
 pytest
 
 # The following dependencies are actually optional:
 ecdsa
+filelock


### PR DESCRIPTION
This is a PR into #235. It detects xdist and imports filelock if and only if the tests are running under xdist, otherwise substituting a no-op.

Two other options:

1. The first commit in this branch attempts to import filelock, but prints a warning if it's not available. The warning looks like:


```
==================================== warnings summary ============================================
irctest/irc_utils/filelock.py:13
  /data/shivaram/workspace/irctest/irctest/irc_utils/filelock.py:13: RuntimeWarning: filelock package unavailable, concurrent runs may race
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================= 415 passed, 20 skipped, 24 deselected, 1 warning in 24.32s =====================
```

2. Just go with your original plan, I don't have a real issue with it.