### PR TITLE
use consistent import style in filelock shim

### DIFF
--- a/irctest/irc_utils/filelock.py
+++ b/irctest/irc_utils/filelock.py
@@ -4,16 +4,15 @@ commonly packaged by Linux distributions but might not be available
 in some environments.
 """
 
+import contextlib
 import os
-from typing import ContextManager
+from typing import Any, ContextManager
 
 if os.getenv("PYTEST_XDIST_WORKER"):
     # running under pytest-xdist; filelock is required for reliability
     from filelock import FileLock
 else:
     # normal test execution, no port races
-    import contextlib
-    from typing import Any
 
     def FileLock(*args: Any, **kwargs: Any) -> ContextManager[None]:
         return contextlib.nullcontext()


### PR DESCRIPTION
This was bugging me for some reason