### PR TITLE
update ergo unicode tests

### DIFF
--- a/irctest/controllers/ergo.py
+++ b/irctest/controllers/ergo.py
@@ -14,6 +14,7 @@ BASE_CONFIG = {
         "name": "My.Little.Server",
         "listeners": {},
         "max-sendq": "16k",
+        "casemapping": "ascii",
         "connection-limits": {
             "enabled": True,
             "cidr-len-ipv4": 32,

--- a/irctest/server_tests/confusables.py
+++ b/irctest/server_tests/confusables.py
@@ -12,8 +12,8 @@ class ConfusablesTestCase(cases.BaseServerTestCase):
     @staticmethod
     def config() -> cases.TestCaseControllerConfig:
         return cases.TestCaseControllerConfig(
-            ergo_config=lambda config: config["accounts"].update(
-                {"nick-reservation": {"enabled": True, "method": "strict"}}
+            ergo_config=lambda config: config["server"].update(
+                {"casemapping": "precis"},
             )
         )
 


### PR DESCRIPTION
* `casemapping: ascii` is now default
* test that non-ascii nicks are rejected by default
* test that non-ascii nicks are accepted under `casemapping: precis`