### PR TITLE
ci: upgrade actions/setup-go

### DIFF
--- a/.github/workflows/test-devel.yml
+++ b/.github/workflows/test-devel.yml
@@ -550,7 +550,7 @@ jobs:
         path: ergo
         ref: master
         repository: ergochat/ergo
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ^1.22.0
     - run: go version

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -626,7 +626,7 @@ jobs:
         path: ergo
         ref: irctest_stable
         repository: ergochat/ergo
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ^1.22.0
     - run: go version

--- a/workflows.yml
+++ b/workflows.yml
@@ -134,7 +134,7 @@ software:
         path: ergo
         prefix: ~/go
         pre_deps:
-            - uses: actions/setup-go@v2
+            - uses: actions/setup-go@v3
               with:
                   go-version: '^1.22.0'
             - run: go version


### PR DESCRIPTION
The root cause of https://github.com/progval/irctest/actions/runs/7863700130/job/21454608952 was indeed fixed by 56e05655126dbe75f25577c0cb37e54e08cdc389, but we might as well upgrade, right?