### PR TITLE
Fix support for latest Anope 2.1

### DIFF
--- a/irctest/controllers/anope_services.py
+++ b/irctest/controllers/anope_services.py
@@ -67,7 +67,7 @@ options {{
 }}
 
 module {{ name = "{module_prefix}sasl" }}
-module {{ name = "enc_sha256" }}
+module {{ name = "enc_bcrypt" }}
 module {{ name = "ns_cert" }}
 
 """


### PR DESCRIPTION
enc_sha256 cannot be loaded since https://github.com/anope/anope/commit/6e0f0b8896deb71cc112d7eadc10eedcc3081cba