### PR TITLE
Makefile: Add selectors in preparation for Sable adding message-tags support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,16 @@ LIMNORIA_SELECTORS := \
 	(foo or not foo) \
 	$(EXTRA_SELECTORS)
 
+# Tests marked with arbitrary_client_tags or react_tag can't pass because Sable does not support client tags yet
+# Tests marked with private_chathistory can't pass because Sable does not implement CHATHISTORY for DMs
+
 SABLE_SELECTORS := \
 	not Ergo \
 	and not deprecated \
 	and not strict \
+	and not arbitrary_client_tags \
+	and not react_tag \
+	and not private_chathistory \
 	and not whowas and not list and not lusers and not userhost and not time and not info \
 	$(EXTRA_SELECTORS)
 


### PR DESCRIPTION
Some tests Sable would fail are currently disabled only because Sable does not support message-tags; but it probably will in the near future https://github.com/Libera-Chat/sable/pull/107)