### PR TITLE
Enable CAP tests for Sable

### DIFF
--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -1106,7 +1106,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: sable
-        ref: dcf8b53cac54f460b86861908d36d67969cf1eb2
+        ref: fe337a036c3ab5f8548e2578b65568e628f4c32f
         repository: Libera-Chat/sable
     - name: Install rust toolchain
       uses: actions-rs/toolchain@v1

--- a/irctest/server_tests/cap.py
+++ b/irctest/server_tests/cap.py
@@ -56,10 +56,6 @@ class CapTestCase(cases.BaseServerTestCase):
         )
 
     @cases.mark_specifications("IRCv3")
-    @cases.xfailIfSoftware(
-        ["Sable"],
-        "does not support multi-prefix",
-    )
     def testReqOne(self):
         """Tests requesting a single capability"""
         self.addClient(1)
@@ -93,7 +89,7 @@ class CapTestCase(cases.BaseServerTestCase):
 
     @cases.mark_specifications("IRCv3")
     @cases.xfailIfSoftware(
-        ["ngIRCd", "Sable"],
+        ["ngIRCd"],
         "does not support userhost-in-names",
     )
     def testReqTwo(self):
@@ -135,7 +131,7 @@ class CapTestCase(cases.BaseServerTestCase):
 
     @cases.mark_specifications("IRCv3")
     @cases.xfailIfSoftware(
-        ["ngIRCd", "Sable"],
+        ["ngIRCd"],
         "does not support userhost-in-names",
     )
     def testReqOneThenOne(self):
@@ -187,7 +183,7 @@ class CapTestCase(cases.BaseServerTestCase):
 
     @cases.mark_specifications("IRCv3")
     @cases.xfailIfSoftware(
-        ["ngIRCd", "Sable"],
+        ["ngIRCd"],
         "does not support userhost-in-names",
     )
     def testReqPostRegistration(self):

--- a/workflows.yml
+++ b/workflows.yml
@@ -249,7 +249,7 @@ software:
         name: Sable
         repository: Libera-Chat/sable
         refs:
-            stable: dcf8b53cac54f460b86861908d36d67969cf1eb2 
+            stable: fe337a036c3ab5f8548e2578b65568e628f4c32f
             release: null
             devel: master
             devel_release: null


### PR DESCRIPTION
It now implements userhost-in-names and multi-prefix, which these tests depend on