### PR TITLE
Enable WHOWAS and USERHOST tests on Sable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ SABLE_SELECTORS := \
 	and not arbitrary_client_tags \
 	and not react_tag \
 	and not private_chathistory \
-	and not whowas and not list and not lusers and not userhost and not time and not info \
+	and not list and not lusers and not time and not info \
 	$(EXTRA_SELECTORS)
 
 SOLANUM_SELECTORS := \

--- a/irctest/server_tests/whowas.py
+++ b/irctest/server_tests/whowas.py
@@ -154,6 +154,9 @@ class WhowasTestCase(cases.BaseServerTestCase):
         except ConnectionClosed:
             pass
 
+        if self.controller.software_name == "Sable":
+            time.sleep(1)  # may take a little while to record the historical user
+
         self.sendLine(1, whowas_command)
 
         messages = self.getMessages(1)


### PR DESCRIPTION
It now implements these commands.