### PR TITLE
fix buffering test

### DIFF
--- a/irctest/server_tests/buffering.py
+++ b/irctest/server_tests/buffering.py
@@ -86,10 +86,10 @@ class BufferingTestCase(cases.BaseServerTestCase):
             if messages and ERR_INPUTTOOLONG in (m.command for m in messages):
                 # https://defs.ircdocs.horse/defs/numerics.html#err-inputtoolong-417
                 self.assertGreater(
-                    len(line + payload + "\r\n"),
+                    len((line + payload + "\r\n").encode()),
                     512 - overhead,
-                    "Got ERR_INPUTTOOLONG for a messag that should fit "
-                    "withing 512 characters.",
+                    "Got ERR_INPUTTOOLONG for a message that should fit "
+                    "within 512 characters.",
                 )
                 continue
 
@@ -125,11 +125,24 @@ class BufferingTestCase(cases.BaseServerTestCase):
                     f"expected payload to be a prefix of {payload!r}, "
                     f"but got {payload!r}",
                 )
+            if self.controller.software_name == "Ergo":
+                self.assertTrue(
+                    payload_intact,
+                    f"Ergo should not truncate messages: {repr(line + payload)}, {repr(received_line)}",
+                )
 
     def get_overhead(self, client1, client2, colon):
-        self.sendLine(client1, f"PRIVMSG nick2 {colon}a\r\n")
+        """Compute the overhead added to client1's message:
+                          PRIVMSG nick2 a\r\n
+        :nick1!~user@host PRIVMSG nick2 :a\r\n
+        So typically client1's NUH length plus either 2 or 3 bytes
+        (the initial colon, the space between source and command, and possibly
+        a colon preceding the trailing).
+        """
+        outgoing = f"PRIVMSG nick2 {colon}a\r\n"
+        self.sendLine(client1, outgoing)
         line = self._getLine(client2)
-        return len(line) - len(f"PRIVMSG nick2 {colon}a\r\n")
+        return len(line) - len(outgoing.encode())
 
     def _getLine(self, client) -> bytes:
         line = b""


### PR DESCRIPTION
The test for erroneous ERR_INPUTTOOLONG was counting codepoints instead of bytes, consequently underestimating the actual relayed size of the message.

This is currently broken in Ergo's stable due to a bug. I figure we can do the following dance:

1. Get this reviewed here
2. I merge this change into Ergo's irctest fork
3. I merge the Ergo fix, bumping Ergo's irctest pointer to the fork
4. I dogfood the Ergo change
5. I merge the Ergo change into Ergo's `irctest_stable` branch
6. We merge this change into irctest's master