### PR TITLE
Add tests for Sable's postgresql chathistory backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,71 +8,72 @@ PYTEST_ARGS ?=
 EXTRA_SELECTORS ?=
 
 BAHAMUT_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	and not strict \
 	and not IRCv3 \
 	$(EXTRA_SELECTORS)
 
 CHARYBDIS_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	and not strict \
 	$(EXTRA_SELECTORS)
 
 ERGO_SELECTORS := \
+	(Ergo or not implementation-specific) \
 	not deprecated \
 	$(EXTRA_SELECTORS)
 
 HYBRID_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	$(EXTRA_SELECTORS)
 
 INSPIRCD_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	and not strict \
 	$(EXTRA_SELECTORS)
 
 IRCU2_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	and not strict \
 	$(EXTRA_SELECTORS)
 
 NEFARIOUS_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	and not strict \
 	$(EXTRA_SELECTORS)
 
 SNIRCD_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	and not strict \
 	$(EXTRA_SELECTORS)
 
 IRC2_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	and not strict \
 	$(EXTRA_SELECTORS)
 
 MAMMON_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	and not strict \
 	$(EXTRA_SELECTORS)
 
 NGIRCD_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	and not strict \
 	$(EXTRA_SELECTORS)
 
 PLEXUS4_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	$(EXTRA_SELECTORS)
 
@@ -87,7 +88,7 @@ LIMNORIA_SELECTORS := \
 # Tests marked with private_chathistory can't pass because Sable does not implement CHATHISTORY for DMs
 
 SABLE_SELECTORS := \
-	not Ergo \
+	(Sable or not implementation-specific) \
 	and not deprecated \
 	and not strict \
 	and not arbitrary_client_tags \
@@ -97,7 +98,7 @@ SABLE_SELECTORS := \
 	$(EXTRA_SELECTORS)
 
 SOLANUM_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	and not strict \
 	$(EXTRA_SELECTORS)
@@ -119,7 +120,7 @@ THELOUNGE_SELECTORS := \
 # Tests marked with private_chathistory can't pass because Unreal does not implement CHATHISTORY for DMs
 
 UNREALIRCD_SELECTORS := \
-	not Ergo \
+	not implementation-specific \
 	and not deprecated \
 	and not strict \
 	and not arbitrary_client_tags \

--- a/irctest/basecontrollers.py
+++ b/irctest/basecontrollers.py
@@ -67,6 +67,9 @@ class TestCaseControllerConfig:
     This should be used as little as possible, using the other attributes instead;
     as they are work with any controller."""
 
+    sable_history_server: bool = False
+    """Whether to start Sable's long-term history server"""
+
 
 class _BaseController:
     """Base class for software controllers.

--- a/irctest/specifications.py
+++ b/irctest/specifications.py
@@ -9,6 +9,7 @@ class Specifications(enum.Enum):
     RFC2812 = "RFC2812"
     IRCv3 = "IRCv3"  # Mark with capabilities whenever possible
     Ergo = "Ergo"
+    Sable = "Sable"
 
     Ircdocs = "ircdocs"
     """Any document on ircdocs.horse (especially defs.ircdocs.horse),
@@ -23,6 +24,9 @@ class Specifications(enum.Enum):
             if spec.value.upper() == name:
                 return spec
         raise ValueError(name)
+
+    def is_implementation_specific(self) -> bool:
+        return self in (Specifications.Ergo, Specifications.Sable)
 
 
 @enum.unique

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,12 @@ markers =
     IRCv3
     modern
     ircdocs
+
+    # implementations for which we have specific test get two markers:
+    # the implementation name and 'implementation-specific'
+    implementation-specific
     Ergo
+    Sable
 
     # misc marks
     strict


### PR DESCRIPTION
Here is how I run the tests:

```
export TMPDIR=/path/to/a/tmpfs
export IRCTEST_DEBUG_LOGS=1
pifpaf run postgresql -- pytest --controller=irctest.controllers.sable -m 'not private_chathistory' -vv irctest/server_tests/chathistory.py -k 'latest and postgres' -s
```