### PR TITLE
Allow any extban format on InspIRCd.

### DIFF
--- a/irctest/controllers/inspircd.py
+++ b/irctest/controllers/inspircd.py
@@ -33,7 +33,8 @@ TEMPLATE_CONFIG = """
       class="ServerOperators"
       >
 
-<options casemapping="ascii">
+<options casemapping="ascii"
+         extbanformat="any">
 
 # Disable 'NOTICE #chan :*** foo invited bar into the channel-
 <security announceinvites="none">


### PR DESCRIPTION
This should stop the mute extban test failing when extbanformat is set to name (which will soon be the default in git master).