### PR TITLE
Fix irctest when using long passwords not supported by bcrypt.

### DIFF
--- a/irctest/controllers/anope_services.py
+++ b/irctest/controllers/anope_services.py
@@ -67,7 +67,8 @@ options {{
 }}
 
 module {{ name = "{module_prefix}sasl" }}
-module {{ name = "enc_bcrypt" }}
+module {{ name = "enc_sha2" }}
+module {{ name = "enc_sha256" }}
 module {{ name = "ns_cert" }}
 
 """


### PR DESCRIPTION
On 2.0 this will use enc_sha256, but on 2.1 this will use enc_sha2.