### PR TITLE
Update registration fail code

### DIFF
--- a/irctest/server_tests/account_registration.py
+++ b/irctest/server_tests/account_registration.py
@@ -199,5 +199,5 @@ class RegisterNoLandGrabsTestCase(cases.BaseServerTestCase):
         msgs = self.getMessages("bar")
         fail_response = [msg for msg in msgs if msg.command == "FAIL"][0]
         self.assertMessageMatch(
-            fail_response, params=["REGISTER", "USERNAME_EXISTS", ANYSTR, ANYSTR]
+            fail_response, params=["REGISTER", "ACCOUNT_EXISTS", ANYSTR, ANYSTR]
         )


### PR DESCRIPTION
The fail code was updated from USERNAME_EXISTS to ACCOUNT_EXISTS:

https://github.com/ircv3/ircv3-specifications/commit/dd1efcf5c5274c2518371d94b5d3b48889a8f9d1

after this test and the initial implementations were already written.

Not for merge yet (see https://github.com/ergochat/ergo/pull/2268), just want to see which other projects are red.