### PR TITLE
make metadata tests compatible with batch parameter

### DIFF
--- a/irctest/server_tests/metadata_2.py
+++ b/irctest/server_tests/metadata_2.py
@@ -10,7 +10,7 @@ import pytest
 
 from irctest import cases, runner
 from irctest.numerics import RPL_METADATASUBOK
-from irctest.patma import ANYDICT, ANYLIST, ANYSTR, Either, StrRe
+from irctest.patma import ANYDICT, ANYLIST, ANYOPTSTR, ANYSTR, Either, StrRe
 
 CLIENT_NICKS = {
     1: "foo",
@@ -24,8 +24,10 @@ class MetadataTestCase(cases.BaseServerTestCase):
 
         first_msg = messages.pop(0)
         last_msg = messages.pop(-1)
+        # TODO: s/ANYOPTSTR/ANYSTR/, as per spec update to require a batch parameter
+        # indicating the target
         self.assertMessageMatch(
-            first_msg, command="BATCH", params=[StrRe(r"\+.*"), "metadata"]
+            first_msg, command="BATCH", params=[StrRe(r"\+.*"), "metadata", ANYOPTSTR]
         )
         batch_id = first_msg.params[0][1:]
         self.assertMessageMatch(last_msg, command="BATCH", params=["-" + batch_id])


### PR DESCRIPTION
We're updating the spec to add a batch parameter to metadata. This makes the tests compatible with both versions of the spec for now; eventually we'll update Ergo and the Unreal module to match the new spec, at which point we can make the batch parameter a hard requirement.