### PR TITLE
Fix irctest with the latest Anope git.

### DIFF
--- a/irctest/controllers/anope_services.py
+++ b/irctest/controllers/anope_services.py
@@ -64,7 +64,9 @@ options {{
     readtimeout = 5s
 }}
 
-module {{ name = "ns_sasl" }} # 2.1
+module {{ name = "ns_sasl" }}          # 2.1
+module {{ name = "ns_sasl_external" }} # 2.1
+module {{ name = "ns_sasl_plain" }}    # 2.1
 module {{ name = "m_sasl" }}  # 2.0
 
 module {{ name = "enc_sha2" }}   # 2.1


### PR DESCRIPTION
I'm implementing SCRAM-SHA-256 support and as part of this the SASL module is getting split up so servers can choose what mechanisms they support. This requires some extra modules to be loaded by irctest as it doesn't use our example configs.