### PR TITLE
Fix building InspIRCd after the switch to CMake.

### DIFF
--- a/.github/workflows/test-devel.yml
+++ b/.github/workflows/test-devel.yml
@@ -295,9 +295,22 @@ jobs:
         submodules: ''
     - name: Build InspIRCd
       run: |
-        ./configure --prefix=$HOME/.local/inspircd --development
-        CXXFLAGS=-DINSPIRCD_UNLIMITED_MAINLOOP make -j 4
-        make install
+        export CXXFLAGS="-DINSPIRCD_UNLIMITED_MAINLOOP"
+        if [ -f CMakeLists.txt ]
+        then
+            # We are building v5 or newer
+            sudo apt-get install ninja-build --no-install-recommends
+            cmake -B build \
+                  -D CMAKE_BUILD_TYPE=Debug \
+                  -D CMAKE_INSTALL_PREFIX=$HOME/.local/inspircd \
+                  -D CMAKE_UNITY_BUILD=ON \
+                  -G Ninja
+            ninja -C build install
+        else
+            # We are building v4 or older
+           ./configure --prefix=$HOME/.local/inspircd --development
+            make -j $(nproc) install
+        fi
       working-directory: inspircd
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-inspircd.tar.gz .local/ go/

--- a/.github/workflows/test-devel_release.yml
+++ b/.github/workflows/test-devel_release.yml
@@ -66,9 +66,22 @@ jobs:
         submodules: ''
     - name: Build InspIRCd
       run: |
-        ./configure --prefix=$HOME/.local/inspircd --development
-        CXXFLAGS=-DINSPIRCD_UNLIMITED_MAINLOOP make -j 4
-        make install
+        export CXXFLAGS="-DINSPIRCD_UNLIMITED_MAINLOOP"
+        if [ -f CMakeLists.txt ]
+        then
+            # We are building v5 or newer
+            sudo apt-get install ninja-build --no-install-recommends
+            cmake -B build \
+                  -D CMAKE_BUILD_TYPE=Debug \
+                  -D CMAKE_INSTALL_PREFIX=$HOME/.local/inspircd \
+                  -D CMAKE_UNITY_BUILD=ON \
+                  -G Ninja
+            ninja -C build install
+        else
+            # We are building v4 or older
+           ./configure --prefix=$HOME/.local/inspircd --development
+            make -j $(nproc) install
+        fi
       working-directory: inspircd
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-inspircd.tar.gz .local/ go/

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -339,9 +339,22 @@ jobs:
         submodules: ''
     - name: Build InspIRCd
       run: |
-        ./configure --prefix=$HOME/.local/inspircd --development
-        CXXFLAGS=-DINSPIRCD_UNLIMITED_MAINLOOP make -j 4
-        make install
+        export CXXFLAGS="-DINSPIRCD_UNLIMITED_MAINLOOP"
+        if [ -f CMakeLists.txt ]
+        then
+            # We are building v5 or newer
+            sudo apt-get install ninja-build --no-install-recommends
+            cmake -B build \
+                  -D CMAKE_BUILD_TYPE=Debug \
+                  -D CMAKE_INSTALL_PREFIX=$HOME/.local/inspircd \
+                  -D CMAKE_UNITY_BUILD=ON \
+                  -G Ninja
+            ninja -C build install
+        else
+            # We are building v4 or older
+           ./configure --prefix=$HOME/.local/inspircd --development
+            make -j $(nproc) install
+        fi
       working-directory: inspircd
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-inspircd.tar.gz .local/ go/

--- a/workflows.yml
+++ b/workflows.yml
@@ -155,9 +155,22 @@ software:
         cache: false  # incremental compilation is frequently broken
         separate_build_job: true
         build_script: &inspircd_build_script |
-            ./configure --prefix=$HOME/.local/inspircd --development
-            CXXFLAGS=-DINSPIRCD_UNLIMITED_MAINLOOP make -j 4
-            make install
+            export CXXFLAGS="-DINSPIRCD_UNLIMITED_MAINLOOP"
+            if [ -f CMakeLists.txt ]
+            then
+                # We are building v5 or newer
+                sudo apt-get install ninja-build --no-install-recommends
+                cmake -B build \
+                      -D CMAKE_BUILD_TYPE=Debug \
+                      -D CMAKE_INSTALL_PREFIX=$HOME/.local/inspircd \
+                      -D CMAKE_UNITY_BUILD=ON \
+                      -G Ninja
+                ninja -C build install
+            else
+                # We are building v4 or older
+               ./configure --prefix=$HOME/.local/inspircd --development
+                make -j $(nproc) install
+            fi
     irc2:
         name: irc2
         separate_build_job: false


### PR DESCRIPTION
I thought this would automatically keep working but I forgot about the new build directory stuff.

CMake is unfortunately slower than our previous hand-rolled build system so taken some countermeasures to make it faster:

1. Debug build instead of Release
2. Enabling unity build
3. Ninja instead of Make

I'll be making some changes to InspIRCd in the future to make it use C++20 modules which should speed up the build even more.