### PR TITLE
Various improvements to irctest running on GitHub Actions

### DIFF
--- a/.github/workflows/test-devel.yml
+++ b/.github/workflows/test-devel.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-anope-devel
         path: '~/.cache
@@ -16,9 +16,9 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -26,7 +26,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: anope
         ref: '2.1'
@@ -42,7 +42,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-anope.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-anope
         path: ~/artefacts-*.tar.gz
@@ -53,7 +53,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-anope-2-0-devel
         path: '~/.cache
@@ -61,9 +61,9 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -71,7 +71,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope 2.0
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: anope
         ref: '2.0'
@@ -87,7 +87,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-anope-2-0.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-anope-2-0
         path: ~/artefacts-*.tar.gz
@@ -98,7 +98,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-atheme-devel
         path: '~/.cache
@@ -106,9 +106,9 @@ jobs:
           ${ github.workspace }/atheme
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -116,7 +116,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Atheme
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: atheme
         ref: release/7.2
@@ -132,7 +132,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-atheme.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-atheme
         path: ~/artefacts-*.tar.gz
@@ -143,7 +143,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-atheme-7-3-devel
         path: '~/.cache
@@ -151,9 +151,9 @@ jobs:
           ${ github.workspace }/atheme
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -161,7 +161,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Atheme
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: atheme
         ref: master
@@ -177,7 +177,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-atheme-7-3.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-atheme-7-3
         path: ~/artefacts-*.tar.gz
@@ -188,7 +188,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-bahamut-devel
         path: '~/.cache
@@ -196,9 +196,9 @@ jobs:
           ${ github.workspace }/Bahamut
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -206,7 +206,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Bahamut
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: Bahamut
         ref: master
@@ -235,7 +235,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-bahamut.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-bahamut
         path: ~/artefacts-*.tar.gz
@@ -246,7 +246,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-hybrid-devel
         path: '~/.cache
@@ -254,9 +254,9 @@ jobs:
           ${ github.workspace }/ircd-hybrid
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -264,7 +264,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Hybrid
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: ircd-hybrid
         ref: 8.2.x
@@ -281,7 +281,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-hybrid.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-hybrid
         path: ~/artefacts-*.tar.gz
@@ -291,9 +291,9 @@ jobs:
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -301,7 +301,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout InspIRCd
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: inspircd
         ref: master
@@ -329,7 +329,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-inspircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-inspircd
         path: ~/artefacts-*.tar.gz
@@ -340,7 +340,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-ngircd-devel
         path: '~/.cache
@@ -348,9 +348,9 @@ jobs:
           ${ github.workspace }/ngircd
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -358,7 +358,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout ngircd
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: ngircd
         ref: master
@@ -375,7 +375,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-ngircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-ngircd
         path: ~/artefacts-*.tar.gz
@@ -386,7 +386,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-plexus4-devel
         path: '~/.cache
@@ -394,9 +394,9 @@ jobs:
           ${ github.workspace }/placeholder
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -420,7 +420,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-plexus4.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-plexus4
         path: ~/artefacts-*.tar.gz
@@ -431,7 +431,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-solanum-devel
         path: '~/.cache
@@ -439,9 +439,9 @@ jobs:
           ${ github.workspace }/solanum
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -449,7 +449,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Solanum
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: solanum
         ref: main
@@ -465,7 +465,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-solanum.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-solanum
         path: ~/artefacts-*.tar.gz
@@ -476,7 +476,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-unrealircd-devel
         path: '~/.cache
@@ -484,9 +484,9 @@ jobs:
           ${ github.workspace }/unrealircd
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -494,7 +494,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout UnrealIRCd 6
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: unrealircd
         ref: unreal60_dev
@@ -517,7 +517,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-unrealircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-unrealircd
         path: ~/artefacts-*.tar.gz
@@ -552,9 +552,9 @@ jobs:
     - test-unrealircd-dlk
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Download Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: artifacts
     - name: Install dashboard dependencies
@@ -579,13 +579,13 @@ jobs:
     - build-bahamut
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-bahamut
         path: '~'
@@ -605,7 +605,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_bahamut_devel
         path: pytest.xml
@@ -615,18 +615,18 @@ jobs:
     - build-anope-2-0
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-bahamut
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope-2-0
         path: '~'
@@ -646,7 +646,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_bahamut-anope_devel
         path: pytest.xml
@@ -656,18 +656,18 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-bahamut
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-atheme
         path: '~'
@@ -687,7 +687,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_bahamut-atheme_devel
         path: pytest.xml
@@ -695,13 +695,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout Ergo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: ergo
         ref: master
@@ -730,7 +730,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_ergo_devel
         path: pytest.xml
@@ -740,18 +740,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-hybrid
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -771,7 +771,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_hybrid_devel
         path: pytest.xml
@@ -780,13 +780,13 @@ jobs:
     - build-inspircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-inspircd
         path: '~'
@@ -806,7 +806,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_inspircd_devel
         path: pytest.xml
@@ -816,18 +816,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-inspircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -847,7 +847,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_inspircd-anope_devel
         path: pytest.xml
@@ -855,13 +855,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout ircu2
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: ircu2
         ref: main
@@ -893,7 +893,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_ircu2_devel
         path: pytest.xml
@@ -901,7 +901,7 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -923,7 +923,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_limnoria_devel
         path: pytest.xml
@@ -931,13 +931,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout nefarious
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: nefarious
         ref: master
@@ -964,7 +964,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_nefarious_devel
         path: pytest.xml
@@ -973,13 +973,13 @@ jobs:
     - build-ngircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-ngircd
         path: '~'
@@ -999,7 +999,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_ngircd_devel
         path: pytest.xml
@@ -1009,18 +1009,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-ngircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -1040,7 +1040,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_ngircd-anope_devel
         path: pytest.xml
@@ -1050,18 +1050,18 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-ngircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-atheme
         path: '~'
@@ -1081,7 +1081,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_ngircd-atheme_devel
         path: pytest.xml
@@ -1091,18 +1091,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-plexus4
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -1122,7 +1122,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_plexus4_devel
         path: pytest.xml
@@ -1130,13 +1130,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout Sable
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: sable
         ref: master
@@ -1189,7 +1189,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_sable_devel
         path: pytest.xml
@@ -1198,13 +1198,13 @@ jobs:
     - build-solanum
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-solanum
         path: '~'
@@ -1224,7 +1224,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_solanum_devel
         path: pytest.xml
@@ -1234,18 +1234,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-solanum
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -1265,7 +1265,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_solanum-anope_devel
         path: pytest.xml
@@ -1275,18 +1275,18 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-solanum
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-atheme
         path: '~'
@@ -1306,7 +1306,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_solanum-atheme_devel
         path: pytest.xml
@@ -1314,7 +1314,7 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1335,7 +1335,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_sopel_devel
         path: pytest.xml
@@ -1343,13 +1343,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout TheLounge
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: thelounge
         ref: master
@@ -1376,7 +1376,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_thelounge_devel
         path: pytest.xml
@@ -1385,13 +1385,13 @@ jobs:
     - build-unrealircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-unrealircd
         path: '~'
@@ -1411,7 +1411,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_unrealircd_devel
         path: pytest.xml
@@ -1421,18 +1421,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-unrealircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -1452,7 +1452,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_unrealircd-anope_devel
         path: pytest.xml
@@ -1462,18 +1462,18 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-unrealircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-atheme
         path: '~'
@@ -1493,7 +1493,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_unrealircd-atheme_devel
         path: pytest.xml
@@ -1502,20 +1502,20 @@ jobs:
     - build-unrealircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-unrealircd
         path: '~'
     - name: Unpack artefacts
       run: cd ~; find -name 'artefacts-*.tar.gz' -exec tar -xzf '{}' \;
     - name: Checkout Dlk
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: Dlk-Services
         ref: main
@@ -1543,7 +1543,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_unrealircd-dlk_devel
         path: pytest.xml

--- a/.github/workflows/test-devel.yml
+++ b/.github/workflows/test-devel.yml
@@ -23,6 +23,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope
       uses: actions/checkout@v4
       with:
@@ -66,6 +68,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope 2.0
       uses: actions/checkout@v4
       with:
@@ -109,6 +113,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Atheme
       uses: actions/checkout@v4
       with:
@@ -152,6 +158,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Atheme
       uses: actions/checkout@v4
       with:
@@ -195,6 +203,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Bahamut
       uses: actions/checkout@v4
       with:
@@ -217,7 +227,7 @@ jobs:
         automake --force-missing --add-missing || true
         autoreconf
         ./configure --prefix=$HOME/.local/
-        make -j 4
+        make
         make install
         mkdir -p $HOME/.local/bin/
         cp $HOME/.local/ircd $HOME/.local/bin/ircd
@@ -251,6 +261,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Hybrid
       uses: actions/checkout@v4
       with:
@@ -263,7 +275,7 @@ jobs:
     - name: Build Hybrid
       run: |
         ./configure --prefix=$HOME/.local/
-        make -j 4
+        make
         make install
       working-directory: ircd-hybrid
     - name: Make artefact tarball
@@ -286,6 +298,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout InspIRCd
       uses: actions/checkout@v4
       with:
@@ -309,7 +323,7 @@ jobs:
         else
             # We are building v4 or older
            ./configure --prefix=$HOME/.local/inspircd --development
-            make -j $(nproc) install
+            make install
         fi
       working-directory: inspircd
     - name: Make artefact tarball
@@ -341,6 +355,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout ngircd
       uses: actions/checkout@v4
       with:
@@ -353,7 +369,7 @@ jobs:
         patch src/ngircd/client.c < $GITHUB_WORKSPACE/patches/ngircd_whowas_delay.patch
         ./autogen.sh
         ./configure --prefix=$HOME/.local/
-        make -j 4
+        make
         make install
       working-directory: ngircd
     - name: Make artefact tarball
@@ -385,6 +401,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: clone
       run: 'curl https://gitlab.com/rizon/plexus4/-/archive/master/plexus4-master.tar.gz
         | tar -zx
@@ -395,7 +413,7 @@ jobs:
 
         ./configure --prefix=$HOME/.local/
 
-        make -j 4
+        make
 
         make install'
       working-directory: plexus4
@@ -428,6 +446,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Solanum
       uses: actions/checkout@v4
       with:
@@ -439,7 +459,7 @@ jobs:
       run: |
         ./autogen.sh
         ./configure --prefix=$HOME/.local/ --enable-fhs-paths
-        make -j 4
+        make
         make install
       working-directory: solanum
     - name: Make artefact tarball
@@ -471,6 +491,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout UnrealIRCd 6
       uses: actions/checkout@v4
       with:
@@ -487,7 +509,7 @@ jobs:
         # worker combinations
         sudo apt install libsodium-dev libargon2-dev
         CFLAGS="-O0 -march=x86-64" CXXFLAGS="$CFLAGS" ./Config -quick
-        make -j 4
+        make
         make install
         # Prevent download of geoIP database on first startup
         sed -i 's/loadmodule "geoip_classic";//' ~/.local/unrealircd/conf/modules.default.conf
@@ -854,7 +876,7 @@ jobs:
         # We need --with-maxcon, to set MAXCONNECTIONS so that it's much lower than
         # NN_MAX_CLIENT, or ircu2 crashes with a somewhat cryptic error on startup.
         ./configure --prefix=$HOME/.local/ --with-maxcon=1024 --enable-debug
-        make -j 4
+        make
         make install
       working-directory: ircu2
     - name: Install system dependencies
@@ -924,7 +946,7 @@ jobs:
     - name: Build nefarious
       run: |
         ./configure --prefix=$HOME/.local/ --enable-debug
-        make -j 4
+        make
         echo -e "N\n\n\n\n\n\n\n\n" | make install
         cp $GITHUB_WORKSPACE/data/nefarious/* $HOME/.local/lib
       working-directory: nefarious

--- a/.github/workflows/test-devel.yml
+++ b/.github/workflows/test-devel.yml
@@ -1355,6 +1355,9 @@ jobs:
         ref: master
         repository: thelounge/thelounge
         submodules: ''
+    - uses: actions/setup-node@v6
+      with:
+        node-version: lts/*
     - name: Build TheLounge
       run: |
         yarn install

--- a/.github/workflows/test-devel_release.yml
+++ b/.github/workflows/test-devel_release.yml
@@ -23,6 +23,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope
       uses: actions/checkout@v4
       with:
@@ -57,6 +59,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout InspIRCd
       uses: actions/checkout@v4
       with:
@@ -80,7 +84,7 @@ jobs:
         else
             # We are building v4 or older
            ./configure --prefix=$HOME/.local/inspircd --development
-            make -j $(nproc) install
+            make install
         fi
       working-directory: inspircd
     - name: Make artefact tarball

--- a/.github/workflows/test-devel_release.yml
+++ b/.github/workflows/test-devel_release.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-anope-devel_release
         path: '~/.cache
@@ -16,9 +16,9 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -26,7 +26,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: anope
         ref: '2.0'
@@ -42,7 +42,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-anope.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-anope
         path: ~/artefacts-*.tar.gz
@@ -52,9 +52,9 @@ jobs:
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -62,7 +62,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout InspIRCd
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: inspircd
         ref: insp4
@@ -90,7 +90,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-inspircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-inspircd
         path: ~/artefacts-*.tar.gz
@@ -103,9 +103,9 @@ jobs:
     - test-inspircd-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Download Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: artifacts
     - name: Install dashboard dependencies
@@ -130,13 +130,13 @@ jobs:
     - build-inspircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-inspircd
         path: '~'
@@ -156,7 +156,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_inspircd_devel_release
         path: pytest.xml
@@ -166,18 +166,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-inspircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -197,7 +197,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_inspircd-anope_devel_release
         path: pytest.xml

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-anope-stable
         path: '~/.cache
@@ -16,9 +16,9 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -26,7 +26,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: anope
         ref: 2.0.18
@@ -42,7 +42,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-anope.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-anope
         path: ~/artefacts-*.tar.gz
@@ -53,7 +53,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-anope-2-0-stable
         path: '~/.cache
@@ -61,9 +61,9 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -71,7 +71,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope 2.0
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: anope
         ref: 2.0.18
@@ -87,7 +87,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-anope-2-0.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-anope-2-0
         path: ~/artefacts-*.tar.gz
@@ -98,7 +98,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-atheme-stable
         path: '~/.cache
@@ -106,9 +106,9 @@ jobs:
           ${ github.workspace }/atheme
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -116,7 +116,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Atheme
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: atheme
         ref: v7.2.12
@@ -132,7 +132,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-atheme.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-atheme
         path: ~/artefacts-*.tar.gz
@@ -143,7 +143,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-atheme-7-3-stable
         path: '~/.cache
@@ -151,9 +151,9 @@ jobs:
           ${ github.workspace }/atheme
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -161,7 +161,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Atheme
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: atheme
         ref: 22b0a326651d7fba5f7c733012191d74afba8883
@@ -177,7 +177,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-atheme-7-3.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-atheme-7-3
         path: ~/artefacts-*.tar.gz
@@ -188,7 +188,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-bahamut-stable
         path: '~/.cache
@@ -196,9 +196,9 @@ jobs:
           ${ github.workspace }/Bahamut
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -206,7 +206,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Bahamut
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: Bahamut
         ref: v2.2.4
@@ -235,7 +235,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-bahamut.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-bahamut
         path: ~/artefacts-*.tar.gz
@@ -246,7 +246,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-charybdis-stable
         path: '~/.cache
@@ -254,9 +254,9 @@ jobs:
           ${ github.workspace }/charybdis
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -264,7 +264,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Charybdis
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: charybdis
         ref: charybdis-4.1.2
@@ -281,7 +281,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-charybdis.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-charybdis
         path: ~/artefacts-*.tar.gz
@@ -292,7 +292,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-hybrid-stable
         path: '~/.cache
@@ -300,9 +300,9 @@ jobs:
           ${ github.workspace }/ircd-hybrid
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -310,7 +310,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Hybrid
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: ircd-hybrid
         ref: 8.2.39
@@ -327,7 +327,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-hybrid.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-hybrid
         path: ~/artefacts-*.tar.gz
@@ -337,9 +337,9 @@ jobs:
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -347,7 +347,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout InspIRCd
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: inspircd
         ref: v4.10.0
@@ -375,7 +375,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-inspircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-inspircd
         path: ~/artefacts-*.tar.gz
@@ -386,7 +386,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-ngircd-stable
         path: '~/.cache
@@ -394,9 +394,9 @@ jobs:
           ${ github.workspace }/ngircd
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -404,7 +404,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout ngircd
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: ngircd
         ref: acf8409c60ccc96beed0a1f990c4f9374823c0ce
@@ -421,7 +421,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-ngircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-ngircd
         path: ~/artefacts-*.tar.gz
@@ -432,7 +432,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-plexus4-stable
         path: '~/.cache
@@ -440,9 +440,9 @@ jobs:
           ${ github.workspace }/placeholder
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -466,7 +466,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-plexus4.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-plexus4
         path: ~/artefacts-*.tar.gz
@@ -477,7 +477,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-solanum-stable
         path: '~/.cache
@@ -485,9 +485,9 @@ jobs:
           ${ github.workspace }/solanum
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -495,7 +495,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Solanum
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: solanum
         ref: 9778247c3dca59370b21c4f34f328c52e8b8c669
@@ -511,7 +511,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-solanum.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-solanum
         path: ~/artefacts-*.tar.gz
@@ -522,7 +522,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: 3-${{ runner.os }}-unrealircd-stable
         path: '~/.cache
@@ -530,9 +530,9 @@ jobs:
           ${ github.workspace }/unrealircd
 
           '
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install system dependencies
@@ -540,7 +540,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout UnrealIRCd 6
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: unrealircd
         ref: 2d145b0f2ca320652037217c860159b4beef37e4
@@ -563,7 +563,7 @@ jobs:
     - name: Make artefact tarball
       run: cd ~; tar -czf artefacts-unrealircd.tar.gz .local/ go/
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: installed-unrealircd
         path: ~/artefacts-*.tar.gz
@@ -600,9 +600,9 @@ jobs:
     - test-unrealircd-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Download Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: artifacts
     - name: Install dashboard dependencies
@@ -627,13 +627,13 @@ jobs:
     - build-bahamut
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-bahamut
         path: '~'
@@ -653,7 +653,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_bahamut_stable
         path: pytest.xml
@@ -663,18 +663,18 @@ jobs:
     - build-anope-2-0
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-bahamut
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope-2-0
         path: '~'
@@ -694,7 +694,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_bahamut-anope_stable
         path: pytest.xml
@@ -704,18 +704,18 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-bahamut
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-atheme
         path: '~'
@@ -735,7 +735,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_bahamut-atheme_stable
         path: pytest.xml
@@ -745,18 +745,18 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-charybdis
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-atheme
         path: '~'
@@ -776,7 +776,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_charybdis_stable
         path: pytest.xml
@@ -784,13 +784,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout Ergo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: ergo
         ref: irctest_stable
@@ -819,7 +819,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_ergo_stable
         path: pytest.xml
@@ -829,18 +829,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-hybrid
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -860,7 +860,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_hybrid_stable
         path: pytest.xml
@@ -869,13 +869,13 @@ jobs:
     - build-inspircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-inspircd
         path: '~'
@@ -895,7 +895,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_inspircd_stable
         path: pytest.xml
@@ -905,18 +905,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-inspircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -936,7 +936,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_inspircd-anope_stable
         path: pytest.xml
@@ -946,18 +946,18 @@ jobs:
     - build-atheme-7-3
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-inspircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-atheme-7-3
         path: '~'
@@ -977,7 +977,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_inspircd-atheme_stable
         path: pytest.xml
@@ -985,13 +985,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout irc2
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: irc2.11.2p3
         ref: 59649f24c3a5c27bad5648b48774f27475bccfd3
@@ -1029,7 +1029,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_irc2_stable
         path: pytest.xml
@@ -1037,13 +1037,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout ircu2
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: ircu2
         ref: 0a8a73f344e4ef5bcdab6d899dd9030bf2b32a8e
@@ -1075,7 +1075,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_ircu2_stable
         path: pytest.xml
@@ -1083,7 +1083,7 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1104,7 +1104,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_limnoria_stable
         path: pytest.xml
@@ -1112,13 +1112,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout nefarious
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: nefarious
         ref: 985704168ecada12d9e53b46df6087ef9d9fb40b
@@ -1145,7 +1145,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_nefarious_stable
         path: pytest.xml
@@ -1154,13 +1154,13 @@ jobs:
     - build-ngircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-ngircd
         path: '~'
@@ -1180,7 +1180,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_ngircd_stable
         path: pytest.xml
@@ -1190,18 +1190,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-ngircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -1221,7 +1221,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_ngircd-anope_stable
         path: pytest.xml
@@ -1231,18 +1231,18 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-ngircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-atheme
         path: '~'
@@ -1262,7 +1262,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_ngircd-atheme_stable
         path: pytest.xml
@@ -1272,18 +1272,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-plexus4
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -1303,7 +1303,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_plexus4_stable
         path: pytest.xml
@@ -1311,13 +1311,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout Sable
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: sable
         ref: 70e61b4cc015537d8906da5286f062a8199fb432
@@ -1370,7 +1370,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_sable_stable
         path: pytest.xml
@@ -1379,13 +1379,13 @@ jobs:
     - build-solanum
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-solanum
         path: '~'
@@ -1405,7 +1405,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_solanum_stable
         path: pytest.xml
@@ -1415,18 +1415,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-solanum
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -1446,7 +1446,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_solanum-anope_stable
         path: pytest.xml
@@ -1456,18 +1456,18 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-solanum
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-atheme
         path: '~'
@@ -1487,7 +1487,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_solanum-atheme_stable
         path: pytest.xml
@@ -1495,7 +1495,7 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1516,7 +1516,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_sopel_stable
         path: pytest.xml
@@ -1524,13 +1524,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout TheLounge
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         path: thelounge
         ref: v4.4.0
@@ -1557,7 +1557,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_thelounge_stable
         path: pytest.xml
@@ -1566,13 +1566,13 @@ jobs:
     - build-unrealircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-unrealircd
         path: '~'
@@ -1592,7 +1592,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_unrealircd_stable
         path: pytest.xml
@@ -1602,18 +1602,18 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-unrealircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-anope
         path: '~'
@@ -1633,7 +1633,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_unrealircd-anope_stable
         path: pytest.xml
@@ -1643,18 +1643,18 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-unrealircd
         path: '~'
     - name: Download build artefacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: installed-atheme
         path: '~'
@@ -1674,7 +1674,7 @@ jobs:
       timeout-minutes: 30
     - if: always()
       name: Publish results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pytest-results_unrealircd-atheme_stable
         path: pytest.xml

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -23,6 +23,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope
       uses: actions/checkout@v4
       with:
@@ -66,6 +68,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope 2.0
       uses: actions/checkout@v4
       with:
@@ -109,6 +113,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Atheme
       uses: actions/checkout@v4
       with:
@@ -152,6 +158,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Atheme
       uses: actions/checkout@v4
       with:
@@ -195,6 +203,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Bahamut
       uses: actions/checkout@v4
       with:
@@ -217,7 +227,7 @@ jobs:
         automake --force-missing --add-missing || true
         autoreconf
         ./configure --prefix=$HOME/.local/
-        make -j 4
+        make
         make install
         mkdir -p $HOME/.local/bin/
         cp $HOME/.local/ircd $HOME/.local/bin/ircd
@@ -251,6 +261,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Charybdis
       uses: actions/checkout@v4
       with:
@@ -263,7 +275,7 @@ jobs:
         patch -p1 < $GITHUB_WORKSPACE/patches/charybdis_ubuntu22.patch
         ./autogen.sh
         ./configure --prefix=$HOME/.local/
-        make -j 4
+        make
         make install
       working-directory: charybdis
     - name: Make artefact tarball
@@ -295,6 +307,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Hybrid
       uses: actions/checkout@v4
       with:
@@ -307,7 +321,7 @@ jobs:
     - name: Build Hybrid
       run: |
         ./configure --prefix=$HOME/.local/
-        make -j 4
+        make
         make install
       working-directory: ircd-hybrid
     - name: Make artefact tarball
@@ -330,6 +344,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout InspIRCd
       uses: actions/checkout@v4
       with:
@@ -353,7 +369,7 @@ jobs:
         else
             # We are building v4 or older
            ./configure --prefix=$HOME/.local/inspircd --development
-            make -j $(nproc) install
+            make install
         fi
       working-directory: inspircd
     - name: Make artefact tarball
@@ -385,6 +401,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout ngircd
       uses: actions/checkout@v4
       with:
@@ -397,7 +415,7 @@ jobs:
         patch src/ngircd/client.c < $GITHUB_WORKSPACE/patches/ngircd_whowas_delay.patch
         ./autogen.sh
         ./configure --prefix=$HOME/.local/
-        make -j 4
+        make
         make install
       working-directory: ngircd
     - name: Make artefact tarball
@@ -429,6 +447,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: clone
       run: 'curl https://gitlab.com/rizon/plexus4/-/archive/20211115_0-611/plexus4-20211115_0-611.tar
         | tar -x
@@ -439,7 +459,7 @@ jobs:
 
         ./configure --prefix=$HOME/.local/
 
-        make -j 4
+        make
 
         make install'
       working-directory: plexus4
@@ -472,6 +492,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Solanum
       uses: actions/checkout@v4
       with:
@@ -483,7 +505,7 @@ jobs:
       run: |
         ./autogen.sh
         ./configure --prefix=$HOME/.local/ --enable-fhs-paths
-        make -j 4
+        make
         make install
       working-directory: solanum
     - name: Make artefact tarball
@@ -515,6 +537,8 @@ jobs:
         python-version: 3.11
     - name: Install system dependencies
       run: sudo apt-get install libltdl-dev
+    - name: Calculate job count
+      run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout UnrealIRCd 6
       uses: actions/checkout@v4
       with:
@@ -531,7 +555,7 @@ jobs:
         # worker combinations
         sudo apt install libsodium-dev libargon2-dev
         CFLAGS="-O0 -march=x86-64" CXXFLAGS="$CFLAGS" ./Config -quick
-        make -j 4
+        make
         make install
         # Prevent download of geoIP database on first startup
         sed -i 's/loadmodule "geoip_classic";//' ~/.local/unrealircd/conf/modules.default.conf
@@ -986,7 +1010,7 @@ jobs:
         echo "#define fork() (0)" >> config.h
 
         # Compile and install
-        make -j 4 all
+        make all
         make install
         mkdir -p $HOME/.local/bin
         cp $HOME/.local/sbin/ircd $HOME/.local/bin/ircd
@@ -1034,7 +1058,7 @@ jobs:
         # We need --with-maxcon, to set MAXCONNECTIONS so that it's much lower than
         # NN_MAX_CLIENT, or ircu2 crashes with a somewhat cryptic error on startup.
         ./configure --prefix=$HOME/.local/ --with-maxcon=1024 --enable-debug
-        make -j 4
+        make
         make install
       working-directory: ircu2
     - name: Install system dependencies
@@ -1103,7 +1127,7 @@ jobs:
     - name: Build nefarious
       run: |
         ./configure --prefix=$HOME/.local/ --enable-debug
-        make -j 4
+        make
         echo -e "N\n\n\n\n\n\n\n\n" | make install
         cp $GITHUB_WORKSPACE/data/nefarious/* $HOME/.local/lib
       working-directory: nefarious

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -1536,6 +1536,9 @@ jobs:
         ref: v4.4.0
         repository: thelounge/thelounge
         submodules: ''
+    - uses: actions/setup-node@v6
+      with:
+        node-version: lts/*
     - name: Build TheLounge
       run: |
         yarn install

--- a/make_workflows.py
+++ b/make_workflows.py
@@ -65,7 +65,7 @@ def get_install_steps(*, software_config, software_id, version_flavor):
         install_steps = [
             {
                 "name": f"Checkout {name}",
-                "uses": "actions/checkout@v4",
+                "uses": "actions/checkout@v5",
                 "with": {
                     "repository": software_config["repository"],
                     "ref": ref,
@@ -96,7 +96,7 @@ def get_build_job(*, software_config, software_id, version_flavor):
         cache = [
             {
                 "name": "Cache dependencies",
-                "uses": "actions/cache@v4",
+                "uses": "actions/cache@v5",
                 "with": {
                     "path": f"~/.cache\n${{ github.workspace }}/{path}\n",
                     "key": "3-${{ runner.os }}-"
@@ -125,10 +125,10 @@ def get_build_job(*, software_config, software_id, version_flavor):
                 "run": "cd ~/; mkdir -p .local/ go/",
             },
             *cache,
-            {"uses": "actions/checkout@v4"},
+            {"uses": "actions/checkout@v5"},
             {
                 "name": "Set up Python 3.11",
-                "uses": "actions/setup-python@v5",
+                "uses": "actions/setup-python@v6",
                 "with": {"python-version": 3.11},
             },
             {
@@ -170,7 +170,7 @@ def get_test_job(*, config, test_config, test_id, version_flavor, jobs):
             downloads.append(
                 {
                     "name": "Download build artefacts",
-                    "uses": "actions/download-artifact@v4",
+                    "uses": "actions/download-artifact@v8",
                     "with": {"name": f"installed-{software_id}", "path": "~"},
                 }
             )
@@ -205,7 +205,7 @@ def get_test_job(*, config, test_config, test_id, version_flavor, jobs):
         "runs-on": "ubuntu-24.04",
         "needs": needs,
         "steps": [
-            {"uses": "actions/checkout@v4"},
+            {"uses": "actions/checkout@v5"},
             {
                 "name": "Set up Python 3.11",
                 "uses": "actions/setup-python@v5",
@@ -245,7 +245,7 @@ def get_test_job(*, config, test_config, test_id, version_flavor, jobs):
             {
                 "name": "Publish results",
                 "if": "always()",
-                "uses": "actions/upload-artifact@v4",
+                "uses": "actions/upload-artifact@v7",
                 "with": {
                     "name": f"pytest-results_{test_id}_{version_flavor.value}",
                     "path": "pytest.xml",
@@ -264,7 +264,7 @@ def upload_steps(software_id):
         },
         {
             "name": "Upload build artefacts",
-            "uses": "actions/upload-artifact@v4",
+            "uses": "actions/upload-artifact@v7",
             "with": {
                 "name": f"installed-{software_id}",
                 "path": "~/artefacts-*.tar.gz",
@@ -330,10 +330,10 @@ def generate_workflow(config: dict, version_flavor: VersionFlavor):
         # this job then
         "if": "success() || failure()",
         "steps": [
-            {"uses": "actions/checkout@v4"},
+            {"uses": "actions/checkout@v5"},
             {
                 "name": "Download Artifacts",
-                "uses": "actions/download-artifact@v4",
+                "uses": "actions/download-artifact@v8",
                 "with": {"path": "artifacts"},
             },
             {

--- a/make_workflows.py
+++ b/make_workflows.py
@@ -135,6 +135,10 @@ def get_build_job(*, software_config, software_id, version_flavor):
                 "name": "Install system dependencies",
                 "run": "sudo apt-get install libltdl-dev",
             },
+            {
+                "name": "Calculate job count",
+                "run": "echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV",
+            },
             *install_steps,
             *upload_steps(software_id),
         ],

--- a/workflows.yml
+++ b/workflows.yml
@@ -472,6 +472,10 @@ software:
             devel: "master"
             devel_release: null
         path: thelounge
+        pre_deps:
+            - uses: actions/setup-node@v6
+              with:
+                node-version: 'lts/*'
         build_script: |
             yarn install
             NODE_ENV=production yarn build

--- a/workflows.yml
+++ b/workflows.yml
@@ -20,7 +20,7 @@ software:
             patch -p1 < $GITHUB_WORKSPACE/patches/charybdis_ubuntu22.patch
             ./autogen.sh
             ./configure --prefix=$HOME/.local/
-            make -j 4
+            make
             make install
 
     hybrid:
@@ -38,7 +38,7 @@ software:
         separate_build_job: true
         build_script: |
             ./configure --prefix=$HOME/.local/
-            make -j 4
+            make
             make install
 
     plexus4:
@@ -55,7 +55,7 @@ software:
                   run: |-
                       ./autogen.sh
                       ./configure --prefix=$HOME/.local/
-                      make -j 4
+                      make
                       make install
                   working-directory: plexus4
             release: null
@@ -68,7 +68,7 @@ software:
                   run: |-
                       ./autogen.sh
                       ./configure --prefix=$HOME/.local/
-                      make -j 4
+                      make
                       make install
                   working-directory: plexus4
             devel_release: null
@@ -88,7 +88,7 @@ software:
         build_script: |
             ./autogen.sh
             ./configure --prefix=$HOME/.local/ --enable-fhs-paths
-            make -j 4
+            make
             make install
 
     #############################
@@ -117,7 +117,7 @@ software:
             automake --force-missing --add-missing || true
             autoreconf
             ./configure --prefix=$HOME/.local/
-            make -j 4
+            make
             make install
             mkdir -p $HOME/.local/bin/
             cp $HOME/.local/ircd $HOME/.local/bin/ircd
@@ -169,7 +169,7 @@ software:
             else
                 # We are building v4 or older
                ./configure --prefix=$HOME/.local/inspircd --development
-                make -j $(nproc) install
+                make install
             fi
     irc2:
         name: irc2
@@ -194,7 +194,7 @@ software:
             echo "#define fork() (0)" >> config.h
 
             # Compile and install
-            make -j 4 all
+            make all
             make install
             mkdir -p $HOME/.local/bin
             cp $HOME/.local/sbin/ircd $HOME/.local/bin/ircd
@@ -217,7 +217,7 @@ software:
             # We need --with-maxcon, to set MAXCONNECTIONS so that it's much lower than
             # NN_MAX_CLIENT, or ircu2 crashes with a somewhat cryptic error on startup.
             ./configure --prefix=$HOME/.local/ --with-maxcon=1024 --enable-debug
-            make -j 4
+            make
             make install
 
     nefarious:
@@ -232,7 +232,7 @@ software:
         separate_build_job: false
         build_script: |
             ./configure --prefix=$HOME/.local/ --enable-debug
-            make -j 4
+            make
             echo -e "N\n\n\n\n\n\n\n\n" | make install
             cp $GITHUB_WORKSPACE/data/nefarious/* $HOME/.local/lib
 
@@ -251,7 +251,7 @@ software:
             patch src/ngircd/client.c < $GITHUB_WORKSPACE/patches/ngircd_whowas_delay.patch
             ./autogen.sh
             ./configure --prefix=$HOME/.local/
-            make -j 4
+            make
             make install
 
     sable:
@@ -312,7 +312,7 @@ software:
             # We need --with-maxcon, to set MAXCONNECTIONS so that it's much lower than
             # NN_MAX_CLIENT, or ircu2 crashes with a somewhat cryptic error on startup.
             ./configure --prefix=$HOME/.local/ --with-maxcon=1024 --enable-debug
-            make -j 4
+            make
             make install
 
     unrealircd:
@@ -334,7 +334,7 @@ software:
             # worker combinations
             sudo apt install libsodium-dev libargon2-dev
             CFLAGS="-O0 -march=x86-64" CXXFLAGS="$CFLAGS" ./Config -quick
-            make -j 4
+            make
             make install
             # Prevent download of geoIP database on first startup
             sed -i 's/loadmodule "geoip_classic";//' ~/.local/unrealircd/conf/modules.default.conf


### PR DESCRIPTION
1. The fastest number of make jobs is 1 more than the number of CPU cores on the build system, one for each of the cores and one waiting to run as soon as a CPU core is available. This pull request automatically calculates that and puts it in MAKEFLAGS so each make invocation doesn't need to specify it manually.

2. A bunch of the GitHub action scripts used by the runners are very outdated and spam deprecation warnings. I updated them to the latest release.

3. The new version of The Lounge requires a newer version of Node than is available on the runner. I changed it to install the latest Node LTS as a pre-step so this should never happen again. 