### PR TITLE
multiline: Mark testInvalidBatchTag as Ergo-specific

### DIFF
--- a/irctest/server_tests/multiline.py
+++ b/irctest/server_tests/multiline.py
@@ -136,7 +136,7 @@ class MultilineTestCase(cases.BaseServerTestCase):
         self.assertIn("+client-only-tag", fallback_relay[1].tags)
         self.assertEqual(fallback_relay[0].tags["msgid"], msgid)
 
-    @cases.mark_capabilities("draft/multiline")
+    @cases.mark_specifications("Ergo")
     def testInvalidBatchTag(self):
         """Test that an unexpected change of batch tag results in
         FAIL BATCH MULTILINE_INVALID."""


### PR DESCRIPTION
The spec doesn't require this behavior (just says clients are not allowed to do it), and no other implementation behaves like this: Solanum ignores and Unreal lets it through (discarding the batch tag)