### PR TITLE
Use the GitHub Actions env parameter instead of appending to vars. 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,15 +11,15 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
 
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: |
           ~/.cache

--- a/.github/workflows/test-devel.yml
+++ b/.github/workflows/test-devel.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-anope-devel
         path: '~/.cache
@@ -16,7 +16,7 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -26,7 +26,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: anope
         ref: '2.1'
@@ -59,7 +59,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-anope-2-0-devel
         path: '~/.cache
@@ -67,7 +67,7 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -77,7 +77,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope 2.0
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: anope
         ref: '2.0'
@@ -110,7 +110,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-atheme-devel
         path: '~/.cache
@@ -118,7 +118,7 @@ jobs:
           ${ github.workspace }/atheme
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -128,7 +128,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Atheme
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: atheme
         ref: release/7.2
@@ -155,7 +155,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-atheme-7-3-devel
         path: '~/.cache
@@ -163,7 +163,7 @@ jobs:
           ${ github.workspace }/atheme
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -173,7 +173,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Atheme
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: atheme
         ref: master
@@ -200,7 +200,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-bahamut-devel
         path: '~/.cache
@@ -208,7 +208,7 @@ jobs:
           ${ github.workspace }/Bahamut
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -218,7 +218,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Bahamut
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: Bahamut
         ref: master
@@ -258,7 +258,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-hybrid-devel
         path: '~/.cache
@@ -266,7 +266,7 @@ jobs:
           ${ github.workspace }/ircd-hybrid
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -276,7 +276,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Hybrid
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: ircd-hybrid
         ref: 8.2.x
@@ -303,7 +303,7 @@ jobs:
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -313,7 +313,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout InspIRCd
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: inspircd
         ref: master
@@ -353,7 +353,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-ngircd-devel
         path: '~/.cache
@@ -361,7 +361,7 @@ jobs:
           ${ github.workspace }/ngircd
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -371,7 +371,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout ngircd
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: ngircd
         ref: master
@@ -399,7 +399,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-plexus4-devel
         path: '~/.cache
@@ -407,7 +407,7 @@ jobs:
           ${ github.workspace }/placeholder
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -444,7 +444,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-solanum-devel
         path: '~/.cache
@@ -452,7 +452,7 @@ jobs:
           ${ github.workspace }/solanum
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -462,7 +462,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Solanum
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: solanum
         ref: main
@@ -489,7 +489,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-unrealircd-devel
         path: '~/.cache
@@ -497,7 +497,7 @@ jobs:
           ${ github.workspace }/unrealircd
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -507,7 +507,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout UnrealIRCd 6
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: unrealircd
         ref: unreal60_dev
@@ -568,7 +568,7 @@ jobs:
     - test-unrealircd-dlk
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Download Artifacts
       uses: actions/download-artifact@v8
       with:
@@ -595,7 +595,7 @@ jobs:
     - build-bahamut
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -631,7 +631,7 @@ jobs:
     - build-anope-2-0
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -672,7 +672,7 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -711,19 +711,19 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout Ergo
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: ergo
         ref: master
         repository: ergochat/ergo
         submodules: ''
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v6
       with:
         go-version: ^1.24.0
     - run: go version
@@ -756,7 +756,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -796,7 +796,7 @@ jobs:
     - build-inspircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -832,7 +832,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -871,13 +871,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout ircu2
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: ircu2
         ref: main
@@ -917,7 +917,7 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -947,13 +947,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout nefarious
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: nefarious
         ref: master
@@ -989,7 +989,7 @@ jobs:
     - build-ngircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1025,7 +1025,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1066,7 +1066,7 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1107,7 +1107,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1146,13 +1146,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout Sable
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: sable
         ref: master
@@ -1214,7 +1214,7 @@ jobs:
     - build-solanum
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1250,7 +1250,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1291,7 +1291,7 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1330,7 +1330,7 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1359,13 +1359,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout TheLounge
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: thelounge
         ref: master
@@ -1404,7 +1404,7 @@ jobs:
     - build-unrealircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1440,7 +1440,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1481,7 +1481,7 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1521,7 +1521,7 @@ jobs:
     - build-unrealircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1534,7 +1534,7 @@ jobs:
     - name: Unpack artefacts
       run: cd ~; find -name 'artefacts-*.tar.gz' -exec tar -xzf '{}' \;
     - name: Checkout Dlk
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: Dlk-Services
         ref: main

--- a/.github/workflows/test-devel.yml
+++ b/.github/workflows/test-devel.yml
@@ -615,9 +615,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        bahamut
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make bahamut
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -656,9 +658,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        bahamut-anope
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make bahamut-anope
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -697,9 +701,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        bahamut-atheme
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make bahamut-atheme
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -740,8 +746,10 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/go/sbin:~/go/bin:~/go:$PATH
+      run: |-
+        export PATH=~/.local/bin:~/go/sbin:~/go/bin:~/go:$PATH
         make ergo
       timeout-minutes: 30
     - if: always()
@@ -781,9 +789,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        hybrid
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make hybrid
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -816,8 +826,10 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH
+      run: |-
+        export PATH=~/.local/bin:~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH
         make inspircd
       timeout-minutes: 30
     - if: always()
@@ -857,9 +869,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH  make
-        inspircd-anope
+      run: |-
+        export PATH=~/.local/bin:~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH
+        make inspircd-anope
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -903,9 +917,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        ircu2
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make ircu2
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -933,9 +949,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        limnoria
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make limnoria
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -974,9 +992,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        nefarious
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make nefarious
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1009,8 +1029,10 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local//sbin:~/.local//bin:~/.local/:$PATH
+      run: |-
+        export PATH=~/.local/bin:~/.local//sbin:~/.local//bin:~/.local/:$PATH
         make ngircd
       timeout-minutes: 30
     - if: always()
@@ -1050,9 +1072,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local//sbin:~/.local//bin:~/.local/:$PATH  make
-        ngircd-anope
+      run: |-
+        export PATH=~/.local/bin:~/.local//sbin:~/.local//bin:~/.local/:$PATH
+        make ngircd-anope
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1091,9 +1115,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local//sbin:~/.local//bin:~/.local/:$PATH  make
-        ngircd-atheme
+      run: |-
+        export PATH=~/.local/bin:~/.local//sbin:~/.local//bin:~/.local/:$PATH
+        make ngircd-atheme
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1132,9 +1158,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        plexus4
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make plexus4
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1196,11 +1224,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
-        IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        IRCTEST_DEBUG_LOGS: 1
+        IRCTEST_POSTGRESQL_URL: postgresql://postgres:postgres@localhost
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH
-        IRCTEST_POSTGRESQL_URL=postgresql://postgres:postgres@localhost IRCTEST_DEBUG_LOGS=1
-        PATH=$GITHUB_WORKSPACE/sable/target/debug/sbin:$GITHUB_WORKSPACE/sable/target/debug/bin:$GITHUB_WORKSPACE/sable/target/debug:$PATH
+      run: |-
+        export PATH=~/.local/bin:$GITHUB_WORKSPACE/sable/target/debug/sbin:$GITHUB_WORKSPACE/sable/target/debug/bin:$GITHUB_WORKSPACE/sable/target/debug:$PATH
         make sable
       timeout-minutes: 30
     - if: always()
@@ -1234,9 +1263,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        solanum
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make solanum
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1275,9 +1306,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        solanum-anope
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make solanum-anope
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1316,9 +1349,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        solanum-atheme
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make solanum-atheme
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1345,9 +1380,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        sopel
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make sopel
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1389,9 +1426,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        thelounge
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make thelounge
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1424,8 +1463,10 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH
+      run: |-
+        export PATH=~/.local/bin:~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH
         make unrealircd
       timeout-minutes: 30
     - if: always()
@@ -1465,9 +1506,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH  make
-        unrealircd-anope
+      run: |-
+        export PATH=~/.local/bin:~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH
+        make unrealircd-anope
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1506,9 +1549,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH  make
-        unrealircd-atheme
+      run: |-
+        export PATH=~/.local/bin:~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH
+        make unrealircd-atheme
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1554,11 +1599,14 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        IRCTEST_DLK_PATH: ${{ github.workspace }}/Dlk-Services
+        IRCTEST_WP_CLI_PATH: ${{ github.workspace }}/Dlk-Services/wp-cli.phar
+        IRCTEST_WP_ZIP_PATH: ${{ github.workspace }}/Dlk-Services/wordpress-latest.zip
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH
-        IRCTEST_DLK_PATH="${{ github.workspace }}/Dlk-Services" IRCTEST_WP_CLI_PATH="${{
-        github.workspace }}/Dlk-Services/wp-cli.phar" IRCTEST_WP_ZIP_PATH="${{ github.workspace
-        }}/Dlk-Services/wordpress-latest.zip" make unrealircd-dlk
+      run: |-
+        export PATH=~/.local/bin:~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH
+        make unrealircd-dlk
       timeout-minutes: 30
     - if: always()
       name: Publish results

--- a/.github/workflows/test-devel_release.yml
+++ b/.github/workflows/test-devel_release.yml
@@ -157,8 +157,10 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH
+      run: |-
+        export PATH=~/.local/bin:~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH
         make inspircd
       timeout-minutes: 30
     - if: always()
@@ -198,9 +200,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH  make
-        inspircd-anope
+      run: |-
+        export PATH=~/.local/bin:~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH
+        make inspircd-anope
       timeout-minutes: 30
     - if: always()
       name: Publish results

--- a/.github/workflows/test-devel_release.yml
+++ b/.github/workflows/test-devel_release.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-anope-devel_release
         path: '~/.cache
@@ -16,7 +16,7 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -26,7 +26,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: anope
         ref: '2.0'
@@ -58,7 +58,7 @@ jobs:
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -68,7 +68,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout InspIRCd
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: inspircd
         ref: insp4
@@ -110,7 +110,7 @@ jobs:
     - test-inspircd-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Download Artifacts
       uses: actions/download-artifact@v8
       with:
@@ -137,7 +137,7 @@ jobs:
     - build-inspircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -173,7 +173,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-anope-stable
         path: '~/.cache
@@ -16,7 +16,7 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -26,7 +26,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: anope
         ref: 2.0.20
@@ -59,7 +59,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-anope-2-0-stable
         path: '~/.cache
@@ -67,7 +67,7 @@ jobs:
           ${ github.workspace }/anope
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -77,7 +77,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Anope 2.0
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: anope
         ref: 2.0.18
@@ -110,7 +110,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-atheme-stable
         path: '~/.cache
@@ -118,7 +118,7 @@ jobs:
           ${ github.workspace }/atheme
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -128,7 +128,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Atheme
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: atheme
         ref: v7.2.12
@@ -155,7 +155,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-atheme-7-3-stable
         path: '~/.cache
@@ -163,7 +163,7 @@ jobs:
           ${ github.workspace }/atheme
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -173,7 +173,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Atheme
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: atheme
         ref: 22b0a326651d7fba5f7c733012191d74afba8883
@@ -200,7 +200,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-bahamut-stable
         path: '~/.cache
@@ -208,7 +208,7 @@ jobs:
           ${ github.workspace }/Bahamut
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -218,7 +218,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Bahamut
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: Bahamut
         ref: v2.2.4
@@ -258,7 +258,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-charybdis-stable
         path: '~/.cache
@@ -266,7 +266,7 @@ jobs:
           ${ github.workspace }/charybdis
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -276,7 +276,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Charybdis
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: charybdis
         ref: charybdis-4.1.2
@@ -304,7 +304,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-hybrid-stable
         path: '~/.cache
@@ -312,7 +312,7 @@ jobs:
           ${ github.workspace }/ircd-hybrid
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -322,7 +322,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Hybrid
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: ircd-hybrid
         ref: 8.2.39
@@ -349,7 +349,7 @@ jobs:
     steps:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -359,7 +359,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout InspIRCd
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: inspircd
         ref: v4.11.0
@@ -399,7 +399,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-ngircd-stable
         path: '~/.cache
@@ -407,7 +407,7 @@ jobs:
           ${ github.workspace }/ngircd
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -417,7 +417,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout ngircd
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: ngircd
         ref: acf8409c60ccc96beed0a1f990c4f9374823c0ce
@@ -445,7 +445,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-plexus4-stable
         path: '~/.cache
@@ -453,7 +453,7 @@ jobs:
           ${ github.workspace }/placeholder
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -490,7 +490,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-solanum-stable
         path: '~/.cache
@@ -498,7 +498,7 @@ jobs:
           ${ github.workspace }/solanum
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -508,7 +508,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout Solanum
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: solanum
         ref: eb62eb9cab93ce0519c0ca2c8fa10e688054434d
@@ -535,7 +535,7 @@ jobs:
     - name: Create directories
       run: cd ~/; mkdir -p .local/ go/
     - name: Cache dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         key: 3-${{ runner.os }}-unrealircd-stable
         path: '~/.cache
@@ -543,7 +543,7 @@ jobs:
           ${ github.workspace }/unrealircd
 
           '
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -553,7 +553,7 @@ jobs:
     - name: Calculate job count
       run: echo MAKEFLAGS=-j$(($(getconf _NPROCESSORS_ONLN) + 1)) >> $GITHUB_ENV
     - name: Checkout UnrealIRCd 6
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: unrealircd
         ref: 2d145b0f2ca320652037217c860159b4beef37e4
@@ -616,7 +616,7 @@ jobs:
     - test-unrealircd-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Download Artifacts
       uses: actions/download-artifact@v8
       with:
@@ -643,7 +643,7 @@ jobs:
     - build-bahamut
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -679,7 +679,7 @@ jobs:
     - build-anope-2-0
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -720,7 +720,7 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -761,7 +761,7 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -800,19 +800,19 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout Ergo
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: ergo
         ref: irctest_stable
         repository: ergochat/ergo
         submodules: ''
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v6
       with:
         go-version: ^1.24.0
     - run: go version
@@ -845,7 +845,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -885,7 +885,7 @@ jobs:
     - build-inspircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -921,7 +921,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -962,7 +962,7 @@ jobs:
     - build-atheme-7-3
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1001,13 +1001,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout irc2
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: irc2.11.2p3
         ref: 59649f24c3a5c27bad5648b48774f27475bccfd3
@@ -1053,13 +1053,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout ircu2
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: ircu2
         ref: 0a8a73f344e4ef5bcdab6d899dd9030bf2b32a8e
@@ -1099,7 +1099,7 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1128,13 +1128,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout nefarious
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: nefarious
         ref: 985704168ecada12d9e53b46df6087ef9d9fb40b
@@ -1170,7 +1170,7 @@ jobs:
     - build-ngircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1206,7 +1206,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1247,7 +1247,7 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1288,7 +1288,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1327,13 +1327,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout Sable
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: sable
         ref: 70e61b4cc015537d8906da5286f062a8199fb432
@@ -1395,7 +1395,7 @@ jobs:
     - build-solanum
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1431,7 +1431,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1472,7 +1472,7 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1511,7 +1511,7 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1540,13 +1540,13 @@ jobs:
     needs: []
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Checkout TheLounge
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         path: thelounge
         ref: v4.4.0
@@ -1585,7 +1585,7 @@ jobs:
     - build-unrealircd
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1621,7 +1621,7 @@ jobs:
     - build-anope
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -1662,7 +1662,7 @@ jobs:
     - build-atheme
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -663,9 +663,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        bahamut
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make bahamut
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -704,9 +706,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        bahamut-anope
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make bahamut-anope
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -745,9 +749,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        bahamut-atheme
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make bahamut-atheme
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -786,9 +792,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        charybdis
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make charybdis
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -829,8 +837,10 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/go/sbin:~/go/bin:~/go:$PATH
+      run: |-
+        export PATH=~/.local/bin:~/go/sbin:~/go/bin:~/go:$PATH
         make ergo
       timeout-minutes: 30
     - if: always()
@@ -870,9 +880,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        hybrid
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make hybrid
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -905,8 +917,10 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH
+      run: |-
+        export PATH=~/.local/bin:~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH
         make inspircd
       timeout-minutes: 30
     - if: always()
@@ -946,9 +960,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH  make
-        inspircd-anope
+      run: |-
+        export PATH=~/.local/bin:~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH
+        make inspircd-anope
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -987,9 +1003,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH  make
-        inspircd-atheme
+      run: |-
+        export PATH=~/.local/bin:~/.local/inspircd/sbin:~/.local/inspircd/bin:~/.local/inspircd:$PATH
+        make inspircd-atheme
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1039,9 +1057,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        irc2
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make irc2
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1085,9 +1105,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        ircu2
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make ircu2
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1114,9 +1136,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        limnoria
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make limnoria
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1155,9 +1179,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        nefarious
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make nefarious
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1190,8 +1216,10 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local//sbin:~/.local//bin:~/.local/:$PATH
+      run: |-
+        export PATH=~/.local/bin:~/.local//sbin:~/.local//bin:~/.local/:$PATH
         make ngircd
       timeout-minutes: 30
     - if: always()
@@ -1231,9 +1259,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local//sbin:~/.local//bin:~/.local/:$PATH  make
-        ngircd-anope
+      run: |-
+        export PATH=~/.local/bin:~/.local//sbin:~/.local//bin:~/.local/:$PATH
+        make ngircd-anope
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1272,9 +1302,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local//sbin:~/.local//bin:~/.local/:$PATH  make
-        ngircd-atheme
+      run: |-
+        export PATH=~/.local/bin:~/.local//sbin:~/.local//bin:~/.local/:$PATH
+        make ngircd-atheme
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1313,9 +1345,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        plexus4
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make plexus4
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1377,11 +1411,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
-        IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        IRCTEST_DEBUG_LOGS: 1
+        IRCTEST_POSTGRESQL_URL: postgresql://postgres:postgres@localhost
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH
-        IRCTEST_POSTGRESQL_URL=postgresql://postgres:postgres@localhost IRCTEST_DEBUG_LOGS=1
-        PATH=$GITHUB_WORKSPACE/sable/target/debug/sbin:$GITHUB_WORKSPACE/sable/target/debug/bin:$GITHUB_WORKSPACE/sable/target/debug:$PATH
+      run: |-
+        export PATH=~/.local/bin:$GITHUB_WORKSPACE/sable/target/debug/sbin:$GITHUB_WORKSPACE/sable/target/debug/bin:$GITHUB_WORKSPACE/sable/target/debug:$PATH
         make sable
       timeout-minutes: 30
     - if: always()
@@ -1415,9 +1450,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        solanum
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make solanum
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1456,9 +1493,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        solanum-anope
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make solanum-anope
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1497,9 +1536,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH   make
-        solanum-atheme
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make solanum-atheme
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1526,9 +1567,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        sopel
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make sopel
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1570,9 +1613,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  make
-        thelounge
+      run: |-
+        export PATH=~/.local/bin:$PATH
+        make thelounge
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1605,8 +1650,10 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH
+      run: |-
+        export PATH=~/.local/bin:~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH
         make unrealircd
       timeout-minutes: 30
     - if: always()
@@ -1646,9 +1693,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH  make
-        unrealircd-anope
+      run: |-
+        export PATH=~/.local/bin:~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH
+        make unrealircd-anope
       timeout-minutes: 30
     - if: always()
       name: Publish results
@@ -1687,9 +1736,11 @@ jobs:
         pip install -r requirements.txt pytest-xdist pytest-timeout
     - env:
         IRCTEST_DEBUG_LOGS: ${{ runner.debug }}
+        PYTEST_ARGS: --junit-xml pytest.xml --timeout 300
       name: Test with pytest
-      run: PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' PATH=$HOME/.local/bin:$PATH  PATH=~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH  make
-        unrealircd-atheme
+      run: |-
+        export PATH=~/.local/bin:~/.local/unrealircd/sbin:~/.local/unrealircd/bin:~/.local/unrealircd:$PATH
+        make unrealircd-atheme
       timeout-minutes: 30
     - if: always()
       name: Publish results

--- a/make_workflows.py
+++ b/make_workflows.py
@@ -65,7 +65,7 @@ def get_install_steps(*, software_config, software_id, version_flavor):
         install_steps = [
             {
                 "name": f"Checkout {name}",
-                "uses": "actions/checkout@v5",
+                "uses": "actions/checkout@v7",
                 "with": {
                     "repository": software_config["repository"],
                     "ref": ref,
@@ -96,7 +96,7 @@ def get_build_job(*, software_config, software_id, version_flavor):
         cache = [
             {
                 "name": "Cache dependencies",
-                "uses": "actions/cache@v5",
+                "uses": "actions/cache@v6",
                 "with": {
                     "path": f"~/.cache\n${{ github.workspace }}/{path}\n",
                     "key": "3-${{ runner.os }}-"
@@ -125,7 +125,7 @@ def get_build_job(*, software_config, software_id, version_flavor):
                 "run": "cd ~/; mkdir -p .local/ go/",
             },
             *cache,
-            {"uses": "actions/checkout@v5"},
+            {"uses": "actions/checkout@v7"},
             {
                 "name": "Set up Python 3.11",
                 "uses": "actions/setup-python@v6",
@@ -205,7 +205,7 @@ def get_test_job(*, config, test_config, test_id, version_flavor, jobs):
         "runs-on": "ubuntu-24.04",
         "needs": needs,
         "steps": [
-            {"uses": "actions/checkout@v5"},
+            {"uses": "actions/checkout@v7"},
             {
                 "name": "Set up Python 3.11",
                 "uses": "actions/setup-python@v5",
@@ -330,7 +330,7 @@ def generate_workflow(config: dict, version_flavor: VersionFlavor):
         # this job then
         "if": "success() || failure()",
         "steps": [
-            {"uses": "actions/checkout@v5"},
+            {"uses": "actions/checkout@v7"},
             {
                 "name": "Download Artifacts",
                 "uses": "actions/download-artifact@v8",

--- a/make_workflows.py
+++ b/make_workflows.py
@@ -149,20 +149,25 @@ def get_test_job(*, config, test_config, test_id, version_flavor, jobs):
     if version_flavor.value in test_config.get("exclude_versions", []):
         return None
 
-    env = ""
+    env = {
+        "IRCTEST_DEBUG_LOGS": "${{ runner.debug }}",
+        "PYTEST_ARGS": "--junit-xml pytest.xml --timeout 300",
+    }
+    paths = ["~/.local/bin"]
     needs = []
     downloads = []
     install_steps = []
     for software_id in test_config.get("software", []):
         software_config = config["software"][software_id]
 
-        env += software_config.get("env", "") + " "
+        env |= software_config.get("env", {})
         if "prefix" in software_config:
-            env += (
-                f"PATH={software_config['prefix']}/sbin"
-                f":{software_config['prefix']}/bin"
-                f":{software_config['prefix']}"
-                f":$PATH "
+            paths.extend(
+                [
+                    f"{software_config['prefix']}/sbin",
+                    f"{software_config['prefix']}/bin",
+                    software_config["prefix"],
+                ]
             )
 
         if software_config["separate_build_job"]:
@@ -233,13 +238,10 @@ def get_test_job(*, config, test_config, test_id, version_flavor, jobs):
             {
                 "name": "Test with pytest",
                 "timeout-minutes": 30,
-                "env": {
-                    "IRCTEST_DEBUG_LOGS": "${{ runner.debug }}",
-                },
-                "run": (
-                    f"PYTEST_ARGS='--junit-xml pytest.xml --timeout 300' "
-                    f"PATH=$HOME/.local/bin:$PATH "
-                    f"{env}make {test_id}"
+                "env": env,
+                "run": script(
+                    f'export PATH={":".join(dict.fromkeys(p for p in paths))}:$PATH',
+                    f"make {test_id}",
                 ),
             },
             {

--- a/workflows.yml
+++ b/workflows.yml
@@ -289,7 +289,9 @@ software:
             - name: check postgresql password
               run: |
                 PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -c "SELECT 1;"
-        env: "IRCTEST_POSTGRESQL_URL=postgresql://postgres:postgres@localhost IRCTEST_DEBUG_LOGS=1"
+        env:
+            IRCTEST_POSTGRESQL_URL: postgresql://postgres:postgres@localhost
+            IRCTEST_DEBUG_LOGS: 1
         separate_build_job: false
         build_script: |
             cargo build
@@ -439,10 +441,10 @@ software:
             pip install pifpaf
             wget -q https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
             wget -q https://wordpress.org/wordpress-6.7.2.zip -O wordpress-latest.zip
-        env: >-
-            IRCTEST_DLK_PATH="${{ github.workspace }}/Dlk-Services"
-            IRCTEST_WP_CLI_PATH="${{ github.workspace }}/Dlk-Services/wp-cli.phar"
-            IRCTEST_WP_ZIP_PATH="${{ github.workspace }}/Dlk-Services/wordpress-latest.zip"
+        env:
+            IRCTEST_DLK_PATH: ${{ github.workspace }}/Dlk-Services
+            IRCTEST_WP_CLI_PATH: ${{ github.workspace }}/Dlk-Services/wp-cli.phar
+            IRCTEST_WP_ZIP_PATH: ${{ github.workspace }}/Dlk-Services/wordpress-latest.zip
 
 
     #############################

--- a/workflows.yml
+++ b/workflows.yml
@@ -133,7 +133,7 @@ software:
         path: ergo
         prefix: ~/go
         pre_deps:
-            - uses: actions/setup-go@v3
+            - uses: actions/setup-go@v6
               with:
                   go-version: '^1.24.0'
             - run: go version


### PR DESCRIPTION
This makes reading the output so much easier.

Unfortunately we can't do this for PATH because the home directory isn't know at generation time and there's no `${{ }}` for it but I added a thing to make that a bit easier too.


Whilst I was touching this I bumped the third-party action versions to get rid of the warnings.